### PR TITLE
Add a button to the user block table header to add additional lines

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -385,6 +385,7 @@ const spiHelper_ACTION_VIEW = `
 				<th>Tag</th>
 				<th><span title="Tag the user with a suspected alternate master" class="rt-commentedText spihelper-hovertext">Alt Master</span></th>
 				<th><span title="Request a global lock at Meta:SRG" class="rt-commentedText spihelper-hovertext">Req Lock?</span></th>
+				<th><span title="Add another user" class="rt-commentedText spihelper-hovertext">Add</span></th>
 			</tr>
 			<tr style="border-bottom:2px solid black">
 				<td style="text-align:center;">(All users)</td>
@@ -398,6 +399,7 @@ const spiHelper_ACTION_VIEW = `
 				<td><select id="spiHelper_block_tag_altmaster"/></td>
 	
 				<td><input type="checkbox" name="spiHelper_block_lock_all" id="spiHelper_block_lock"/></td>
+				<td><input type="button" id="moreSerks" value="+" onclick="spiHelper_generateBlockTableLine('', true);"/></td>
 			</tr>
 		</table>
 	</div>

--- a/spihelper.js
+++ b/spihelper.js
@@ -399,7 +399,7 @@ const spiHelper_ACTION_VIEW = `
 				<td><select id="spiHelper_block_tag_altmaster"/></td>
 	
 				<td><input type="checkbox" name="spiHelper_block_lock_all" id="spiHelper_block_lock"/></td>
-				<td><input type="button" id="moreSerks" value="+" onclick="spiHelper_generateBlockTableLine('', true);"/></td>
+				<td><input type="button" id="moreSerks" value="+" onclick="spiHelper_addBlankUserLine();"/></td>
 			</tr>
 		</table>
 	</div>
@@ -2807,4 +2807,14 @@ async function spiHelper_parseArchiveNotice(page) {
 	notice += '}}';
 
 	return notice;
+ }
+
+/**
+ * Function to add a blank user line to the block table
+ * 
+ * @return {void}
+ */
+ function spiHelper_addBlankUserLine() {
+ 	spiHelper_usercount++;
+ 	spiHelper_generateBlockTableLine('', true, spiHelper_usercount);
  }


### PR DESCRIPTION
Add a simple button to the header of the user block table to add a new blank line.

Created a new function `spiHelper_addBlankUserLine()` and added an input button, used the `onclick` to call the new function. Ensured the incrementation of the `spiHelper_usercount` variable.

Resolves #53

![image](https://user-images.githubusercontent.com/35201623/127400823-5aa44dcc-b097-4bcc-8c8a-817becaa1be9.png)
