### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Require review for any deployment related changes
+user-config.py @GeneralNotability
+deploy.py @GeneralNotability
+
+# Require review for any workflow related changes
+.github/workflows/ @GeneralNotability


### PR DESCRIPTION
As you said, it's not paranoia if they really are out to get you.

Configure a [CODEOWNERS file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) to require @GeneralNotability's review if any of these files are changed:

 - `user-config.py`
 - `deploy.py`
 - Any file in `.github/workflows/`