### PR TITLE
Fix `=` signs in lock request usernames

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -1286,11 +1286,11 @@ async function spiHelperPerformActions () {
         if (mw.util.isIPAddress(globalLockEntry, true)) {
           return
         }
-        templateContent += '|' + globalLockEntry
+        templateContent += '|' + (matchCount + 1) + '=' + globalLockEntry
         if (locked) {
           locked += ', '
         }
-        locked += '{{noping|' + globalLockEntry + '}}'
+        locked += '{{noping|1=' + globalLockEntry + '}}'
         matchCount++
       })
 


### PR DESCRIPTION
`{{LockHide}}` and `{{noping}}` gain an explicit `1=` , while `{{MultiLock}}` gains `1=`, `2=`, etc.

Closes #68 