### PR TITLE
Allow running on archive pages for block/tag/lock

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -92,7 +92,7 @@ let spiHelperPageName = mw.config.get('wgPageName').replace(/_/g, ' ')
 let spiHelperStartingRevID = mw.config.get('wgCurRevisionId')
 
 // Just the username part of the case
-let spiHelperCaseName = spiHelperPageName.replace(/Wikipedia:Sockpuppet investigations\//g, '')
+let spiHelperCaseName
 
 /** list of section IDs + names corresponding to separate investigations */
 let spiHelperCaseSections = []
@@ -105,6 +105,8 @@ let spiHelperSectionName = null
 
 /** @type {ParsedArchiveNotice} */
 let spiHelperArchiveNoticeParams
+
+let spiHelperIsThisPageAnArchive
 
 /** Map of top-level actions the user has selected */
 const spiHelperActionsSelected = {
@@ -212,8 +214,7 @@ const spiHelperActiveOperations = new Map()
 
 // Actually put the portlets in place if needed
 if (mw.config.get('wgPageName').includes('Wikipedia:Sockpuppet_investigations/') &&
-  !mw.config.get('wgPageName').includes('Wikipedia:Sockpuppet_investigations/SPI/') &&
-  !mw.config.get('wgPageName').match('Wikipedia:Sockpuppet_investigations/.*/Archive.*')) {
+  !mw.config.get('wgPageName').includes('Wikipedia:Sockpuppet_investigations/SPI/')) {
   mw.loader.load('mediawiki.user')
   $(spiHelperAddLink)
 }
@@ -226,11 +227,11 @@ const spiHelperTopViewHTML = `
   <select id="spiHelper_sectionSelect"></select>
   <h4 id="spiHelper_warning" class="spihelper-errortext" hidden></h4>
   <ul>
-    <li id="spiHelper_actionLine"  class="spiHelper_singleCaseOnly">
+    <li id="spiHelper_actionLine"  class="spiHelper_singleCaseOnly spiHelper_notOnArchive">
       <input type="checkbox" name="spiHelper_Case_Action" id="spiHelper_Case_Action" />
       <label for="spiHelper_Case_Action">Change case status</label>
     </li>
-    <li id="spiHelper_spiMgmtLine"  class="spiHelper_allCasesOnly">
+    <li id="spiHelper_spiMgmtLine"  class="spiHelper_allCasesOnly spiHelper_notOnArchive">
       <input type="checkbox" id="spiHelper_SpiMgmt" />
       <label for="spiHelper_SpiMgmt">Change SPI options</label>
     </li>
@@ -238,19 +239,19 @@ const spiHelperTopViewHTML = `
       <input type="checkbox" name="spiHelper_BlockTag" id="spiHelper_BlockTag" />
       <label for="spiHelper_BlockTag">Block/tag socks</label>
     </li>
-    <li id="spiHelper_commentLine" class="spiHelper_singleCaseOnly">
+    <li id="spiHelper_commentLine" class="spiHelper_singleCaseOnly spiHelper_notOnArchive">
       <input type="checkbox" name="spiHelper_Comment" id="spiHelper_Comment" />
       <label for="spiHelper_Comment">Note/comment</label>
       </li>
-    <li id="spiHelper_closeLine" class="spiHelper_adminClerkClass spiHelper_singleCaseOnly">
+    <li id="spiHelper_closeLine" class="spiHelper_adminClerkClass spiHelper_singleCaseOnly spiHelper_notOnArchive">
       <input type="checkbox" name="spiHelper_Close" id="spiHelper_Close")" />
       <label for="spiHelper_Close">Close case</label>
     </li>
-    <li id="spiHelper_moveLine" class="spiHelper_clerkClass">
+    <li id="spiHelper_moveLine" class="spiHelper_clerkClass spiHelper_notOnArchive">
       <input type="checkbox" name="spiHelper_Move" id="spiHelper_Move" />
       <label for="spiHelper_Move" id="spiHelper_moveLabel">Move/merge full case (Clerk only)</label>
     </li>
-    <li id="spiHelper_archiveLine" class="spiHelper_clerkClass">
+    <li id="spiHelper_archiveLine" class="spiHelper_clerkClass spiHelper_notOnArchive">
       <input type="checkbox" name="spiHelper_Archive" id="spiHelper_Archive"/>
       <label for="spiHelper_Archive">Archive case (Clerk only)</label>
     </li>
@@ -264,10 +265,17 @@ const spiHelperTopViewHTML = `
  */
 async function spiHelperInit () {
   'use strict'
+  spiHelperIsThisPageAnArchive = mw.config.get('wgPageName').match('Wikipedia:Sockpuppet_investigations/.*/Archive.*')
+  if (spiHelperIsThisPageAnArchive) {
+    spiHelperCaseName = spiHelperPageName.replace(/Wikipedia:Sockpuppet investigations\//g, '').replace(/\/Archive/, '')
+  }
+  else {
+    spiHelperCaseName = spiHelperPageName.replace(/Wikipedia:Sockpuppet investigations\//g, '')
+  }
   spiHelperCaseSections = await spiHelperGetInvestigationSectionIDs()
 
   // Load archivenotice params
-  spiHelperArchiveNoticeParams = await spiHelperParseArchiveNotice(spiHelperPageName)
+  spiHelperArchiveNoticeParams = await spiHelperParseArchiveNotice(spiHelperPageName.replace(/\/Archive/, ''))
 
   // First, insert the template text
   displayMessage(spiHelperTopViewHTML)
@@ -310,7 +318,11 @@ async function spiHelperInit () {
   if (!spiHelperIsClerk()) {
     $('.spiHelper_clerkClass', $topView).hide()
   }
-
+  
+  // Only show options suitable for the archive subpage when running on the archives
+  if (spiHelperIsThisPageAnArchive) {
+    $('.spiHelper_notOnArchive', $topView).hide()
+  }
   // Set the checkboxes to their default states
   spiHelperSetCheckboxesBySection()
 }
@@ -689,8 +701,8 @@ async function spiHelperGenerateForm () {
     $('#spiHelper_archiveView', $actionView).hide()
   }
 
-  // Only give the option to comment if we selected a specific section
-  if (spiHelperSectionId) {
+  // Only give the option to comment if we selected a specific section and we are not running on an archive subpage
+  if (spiHelperSectionId && !spiHelperIsThisPageAnArchive) {
     // generate the note prefixes
     /** @type {SelectOption[]} */
     const spiHelperNoteTemplates = [
@@ -807,7 +819,7 @@ async function spiHelperPerformActions () {
     spiHelperArchiveNoticeParams.xwiki = $('#spiHelper_spiMgmt_crosswiki', $actionView).prop('checked')
     spiHelperArchiveNoticeParams.notalk = $('#spiHelper_spiMgmt_notalk', $actionView).prop('checked')
   }
-  if (spiHelperSectionId) {
+  if (spiHelperSectionId && !spiHelperIsThisPageAnArchive) {
     comment = $('#spiHelper_CommentText', $actionView).val().toString()
   }
   if (spiHelperActionsSelected.Block) {
@@ -909,7 +921,7 @@ async function spiHelperPerformActions () {
   }
   logMessage += ' ~~~~~'
 
-  if (spiHelperSectionId !== null) {
+  if (spiHelperSectionId !== null && !spiHelperIsThisPageAnArchive) {
     let caseStatusResult = spiHelperCaseStatusRegex.exec(sectionText)
     if (caseStatusResult === null) {
       sectionText = sectionText.replace('===', '{{SPI case status|}}\n===')
@@ -1346,7 +1358,7 @@ async function spiHelperPerformActions () {
       }
     }
   }
-  if (spiHelperSectionId && comment && comment !== '*') {
+  if (spiHelperSectionId && comment && comment !== '*' && !spiHelperIsThisPageAnArchive) {
     if (!sectionText.includes('\n----')) {
       sectionText += '\n----<!-- All comments go ABOVE this line, please. -->'
     }
@@ -1380,7 +1392,7 @@ async function spiHelperPerformActions () {
     }
     logMessage += '\n** closed case'
   }
-  if (spiHelperSectionId !== null) {
+  if (spiHelperSectionId !== null && !spiHelperIsThisPageAnArchive) {
     const caseStatusText = spiHelperCaseStatusRegex.exec(sectionText)[0]
     sectionText = sectionText.replace(caseStatusText, '{{SPI case status|' + newCaseStatus + '}}')
   }
@@ -1390,16 +1402,18 @@ async function spiHelperPerformActions () {
     editsummary = 'Saving page'
   }
 
-  // Make all of the requested edits (synchronous since we might make more changes to the page)
-  const editResult = await spiHelperEditPage(spiHelperPageName, sectionText, editsummary, false,
-    spiHelperSettings.watchCase, spiHelperSettings.watchCaseExpiry, spiHelperStartingRevID, spiHelperSectionId)
-  if (!editResult) {
-    // Page edit failed (probably an edit conflict), dump the comment if we had one
-    if (comment && comment !== '*') {
-      $('<li>')
-        .append($('<div>').addClass('spihelper-errortext')
-          .append($('<b>').text('SPI page edit failed! Comment was: ' + comment)))
-        .appendTo($('#spiHelper_status', document))
+  // Make all of the requested edits (synchronous since we might make more changes to the page), unless the page is an archive (as there should be no edits made)
+  if (!spiHelperIsThisPageAnArchive) {
+    const editResult = await spiHelperEditPage(spiHelperPageName, sectionText, editsummary, false,
+      spiHelperSettings.watchCase, spiHelperSettings.watchCaseExpiry, spiHelperStartingRevID, spiHelperSectionId)
+    if (!editResult) {
+      // Page edit failed (probably an edit conflict), dump the comment if we had one
+      if (comment && comment !== '*') {
+        $('<li>')
+          .append($('<div>').addClass('spihelper-errortext')
+            .append($('<b>').text('SPI page edit failed! Comment was: ' + comment)))
+          .appendTo($('#spiHelper_status', document))
+      }
     }
   }
   // Update to the latest revision ID

--- a/spihelper.js
+++ b/spihelper.js
@@ -268,8 +268,7 @@ async function spiHelperInit () {
   spiHelperIsThisPageAnArchive = mw.config.get('wgPageName').match('Wikipedia:Sockpuppet_investigations/.*/Archive.*')
   if (spiHelperIsThisPageAnArchive) {
     spiHelperCaseName = spiHelperPageName.replace(/Wikipedia:Sockpuppet investigations\//g, '').replace(/\/Archive/, '')
-  }
-  else {
+  } else {
     spiHelperCaseName = spiHelperPageName.replace(/Wikipedia:Sockpuppet investigations\//g, '')
   }
   spiHelperCaseSections = await spiHelperGetInvestigationSectionIDs()
@@ -318,7 +317,7 @@ async function spiHelperInit () {
   if (!spiHelperIsClerk()) {
     $('.spiHelper_clerkClass', $topView).hide()
   }
-  
+
   // Only show options suitable for the archive subpage when running on the archives
   if (spiHelperIsThisPageAnArchive) {
     $('.spiHelper_notOnArchive', $topView).hide()


### PR DESCRIPTION
Adds functionality to allow the block/tag/lock option to work on subpages:
* Adds the SPI portlet on /Archive subpages
* Only shows the block/tag option for all cases / specific cases
* Makes the block/tag code compatible with running on archive pages by not allowing comments to be made as part of the block/tag/lock
* Ensures that other code that can be run when running on an archive subpage has been updated where needed to account for running on an archive subpage
Fixes #47 