### PR TITLE
Help prevent multiple calls to spiHelperGenerateForm if the button is pressed more than once

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -454,6 +454,7 @@ async function spiHelperGenerateForm () {
   'use strict'
   spiHelperUserCount = 0
   const $topView = $('#spiHelper_topViewDiv', document)
+  $('#spiHelper_GenerateForm', $topView).prop('disabled', true)
   spiHelperActionsSelected.Case_act = $('#spiHelper_Case_Action', $topView).prop('checked')
   spiHelperActionsSelected.Block = $('#spiHelper_BlockTag', $topView).prop('checked')
   spiHelperActionsSelected.Note = $('#spiHelper_Comment', $topView).prop('checked')


### PR DESCRIPTION
Disable the "Continue" button once the onclick button has loaded to help prevent duplicate calls to spiHelperGenerateForm (unless you can click quickly or a broken mouse). Fixes #74 