### PR TITLE
General fixes (small non-functionality changing fixes)

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -758,14 +758,14 @@ async function updateForRole (view) {
   // Hide items based on role
   if (!spiHelperIsCheckuser()) {
     // Hide CU options from non-CUs
-    $('.spiHelper_cuClass', $view).hide()
+    $('.spiHelper_cuClass', view).hide()
   }
   if (!spiHelperIsAdmin()) {
     // Hide block options from non-admins
-    $('.spiHelper_adminClass', $view).hide()
+    $('.spiHelper_adminClass', view).hide()
   }
   if (!(spiHelperIsAdmin() || spiHelperIsClerk())) {
-    $('.spiHelper_adminClerkClass', $view).hide()
+    $('.spiHelper_adminClerkClass', view).hide()
   }
 }
 

--- a/spihelper.js
+++ b/spihelper.js
@@ -261,7 +261,7 @@ const spiHelperTopViewHTML = `
       <label for="spiHelper_Comment">Note/comment</label>
     </li>
     <li id="spiHelper_closeLine" class="spiHelper_adminClerkClass spiHelper_singleCaseOnly">
-      <input type="checkbox" name="spiHelper_Close" id="spiHelper_Close")" />
+      <input type="checkbox" name="spiHelper_Close" id="spiHelper_Close" />
       <label for="spiHelper_Close">Close case</label>
     </li>
     <li id="spiHelper_moveLine" class="spiHelper_clerkClass">

--- a/spihelper.js
+++ b/spihelper.js
@@ -52,6 +52,9 @@ importScript('User:Timotheus Canens/displaymessage.js')
   */
 
 // Globals
+
+/* User setting related globals */
+
 // User-configurable settings, these are the defaults but will be updated by
 // spiHelperLoadSettings()
 const spiHelperSettings = {
@@ -100,6 +103,8 @@ const spiHelperValidSettings = {
   debugForceAdminState: [null, true, false]
 }
 
+/* Globals to describe the current SPI page */
+
 /** @type {string} Name of the SPI page in wiki title form
  * (e.g. Wikipedia:Sockpuppet investigations/Test) */
 let spiHelperPageName = mw.config.get('wgPageName').replace(/_/g, ' ')
@@ -109,7 +114,7 @@ let spiHelperPageName = mw.config.get('wgPageName').replace(/_/g, ' ')
  */
 let spiHelperStartingRevID = mw.config.get('wgCurRevisionId')
 
-// Just the username part of the case
+/** @type {string} Just the username part of the case */
 let spiHelperCaseName = spiHelperPageName.replace(/Wikipedia:Sockpuppet investigations\//g, '')
 
 /** list of section IDs + names corresponding to separate investigations */
@@ -146,7 +151,15 @@ const spiHelperGlobalLocks = []
 
 // Count of unique users in the case (anything with a checkuser, checkip, user, ip, or vandal template on the page)
 let spiHelperUserCount = 0
-const spiHelperSectionRegex = /^(?:===[^=]*===|=====[^=]*=====)\s*$/m
+
+// The current wiki's interwiki prefix
+const spiHelperInterwikiPrefix = spiHelperGetInterwikiPrefix()
+
+// Map of active operations (used as a "dirty" flag for beforeunload)
+// Values are strings representing the state - acceptable values are 'running', 'success', 'failed'
+const spiHelperActiveOperations = new Map()
+
+/* Globals to describe possible options for dropdown menus */
 
 /** @type {SelectOption[]} List of possible selections for tagging a user in the block/tag interface
  */
@@ -198,6 +211,8 @@ const spiHelperAdminTemplates = [
   { label: 'Locks requested', selected: false, value: '{{GlobalLocksRequested}}' }
 ]
 
+/* Globals for regexes */
+
 // Regex to match the case status, group 1 is the actual status
 const spiHelperCaseStatusRegex = /{{\s*SPI case status\s*\|?\s*(\S*?)\s*}}/i
 // Regex to match closed case statuses (close or closed)
@@ -215,20 +230,16 @@ const spiHelperArchiveNoticeRegex = /{{\s*SPI\s*archive notice\|(?:1=)?([^|]*?)(
 
 const spiHelperPriorCasesRegex = /{{spipriorcases}}/i
 
+const spiHelperSectionRegex = /^(?:===[^=]*===|=====[^=]*=====)\s*$/m
+
 // regex to remove hidden characters from form inputs - they mess up some things,
 // especially mw.util.isIP
 const spiHelperHiddenCharNormRegex = /\u200E/g
 
+/** @type{string} Advert to append to the edit summary of edits */
 const spihelperAdvert = ' (using [[:w:en:User:GeneralNotability/spihelper|spihelper.js]])'
 
-// The current wiki's interwiki prefix
-const spiHelperInterwikiPrefix = spiHelperGetInterwikiPrefix()
-
-// Map of active operations (used as a "dirty" flag for beforeunload)
-// Values are strings representing the state - acceptable values are 'running', 'success', 'failed'
-const spiHelperActiveOperations = new Map()
-
-// Actually put the portlets in place if needed
+/* Actually put the portlets in place if needed */
 if (mw.config.get('wgPageName').includes('Wikipedia:Sockpuppet_investigations/') &&
   !mw.config.get('wgPageName').includes('Wikipedia:Sockpuppet_investigations/SPI/') &&
   !mw.config.get('wgPageName').match('Wikipedia:Sockpuppet_investigations/.*/Archive.*')) {

--- a/spihelper.js
+++ b/spihelper.js
@@ -319,15 +319,7 @@ async function spiHelperInit () {
   // All-sections selector...deliberately at the bottom, the default should be the first section
   $('<option>').val('all').text('All Sections').appendTo($sectionSelect)
 
-  // Hide block and close from non-admin non-clerks
-  if (!(spiHelperIsAdmin() || spiHelperIsClerk())) {
-    $('.spiHelper_adminClerkClass', $topView).hide()
-  }
-
-  // Hide move and archive from non-clerks
-  if (!spiHelperIsClerk()) {
-    $('.spiHelper_clerkClass', $topView).hide()
-  }
+  updateForRole($topView)
 
   // Set the checkboxes to their default states
   spiHelperSetCheckboxesBySection()
@@ -754,22 +746,26 @@ async function spiHelperGenerateForm () {
     spiHelperPerformActions()
   })
 
-  updateForRole()
+  updateForRole($actionView)
 }
 
-async function updateForRole () {
-  const $actionView = $('#spiHelper_actionViewDiv', document)
+/**
+ * Update the view for the roles of the person running the script
+ * by selectively hiding.
+ * view: @type JQuery object representing the class / id for the view
+ */
+async function updateForRole (view) {
   // Hide items based on role
   if (!spiHelperIsCheckuser()) {
     // Hide CU options from non-CUs
-    $('.spiHelper_cuClass', $actionView).hide()
+    $('.spiHelper_cuClass', $view).hide()
   }
   if (!spiHelperIsAdmin()) {
     // Hide block options from non-admins
-    $('.spiHelper_adminClass', $actionView).hide()
+    $('.spiHelper_adminClass', $view).hide()
   }
   if (!(spiHelperIsAdmin() || spiHelperIsClerk())) {
-    $('.spiHelper_adminClerkClass', $actionView).hide()
+    $('.spiHelper_adminClerkClass', $view).hide()
   }
 }
 


### PR DESCRIPTION
* Instead of duplicating the code use updateForRole inside spiHelperInit when hiding options for non-admins / non-clerks / non-adminclerks / non-CUs.
* Removed stray bracket in the top view HTML code
* Group the global variables into sections to make it easier to look at the global variables