### PR TITLE
Implement double (or more) SPI redirect fixer

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -1523,15 +1523,15 @@ async function spiHelperPostRenameCleanup (oldCasePage) {
   while (pagesToCheck.length !== 0) {
     currentPageToCheck = pagesToCheck.pop()
     let backlinks = await spiHelperGetSPIBacklinks(currentPageToCheck)
-    backlinks = backlinks.filter((_0, _1, title) => {
-      return spiHelperParseArchiveNotice(title).username === currentPageToCheck.replace(/Wikipedia:Sockpuppet investigations\//g, '')
+    backlinks = backlinks.filter((dictEntry) => {
+      return spiHelperParseArchiveNotice(dictEntry.title).username === currentPageToCheck.replace(/Wikipedia:Sockpuppet investigations\//g, '')
     })
-    backlinks.forEach((_0, _1, title) => {
-      spiHelperEditPage(title, replacementArchiveNotice, 'Updating case following page move', false, spiHelperSettings.watchCase, spiHelperSettings.watchCaseExpiry)
+    backlinks.forEach((dictEntry) => {
+      spiHelperEditPage(dictEntry.title, replacementArchiveNotice, 'Updating case following page move', false, spiHelperSettings.watchCase, spiHelperSettings.watchCaseExpiry)
     })
     pagesChecked.append(currentPageToCheck)
-    backlinks = backlinks.filter((_0, _1, title) => {
-      return pagesChecked.indexOf(title) === -1
+    backlinks = backlinks.filter((dictEntry) => {
+      return pagesChecked.indexOf(dictEntry.title) === -1
     })
     pagesToCheck.conct(backlinks)
   }
@@ -2506,8 +2506,8 @@ async function spiHelperGetSPIBacklinks (casePageName) {
       bldir: 'ascending',
       blfilterredir: 'nonredirects'
     })
-    return response.query.backlinks.filter((pageid, ns, title) => {
-      return title.startsWith('Wikipedia:Sockpuppet investigations/') && !title.startsWith('Wikipedia:Sockpuppet investigations/SPI/') && !title.match('Wikipedia:Sockpuppet investigations/.*/Archive.*')
+    return response.query.backlinks.filter((dictEntry) => {
+      return dictEntry.title.startsWith('Wikipedia:Sockpuppet investigations/') && !dictEntry.title.startsWith('Wikipedia:Sockpuppet investigations/SPI/') && !dictEntry.title.match('Wikipedia:Sockpuppet investigations/.*/Archive.*')
     })
   } catch (error) {
     return []

--- a/spihelper.js
+++ b/spihelper.js
@@ -1530,7 +1530,7 @@ async function spiHelperPostRenameCleanup (oldCasePage) {
       spiHelperEditPage(title, replacementArchiveNotice, 'Updating case following page move', false, spiHelperSettings.watchCase, spiHelperSettings.watchCaseExpiry)
     })
     pagesChecked.append(currentPageToCheck)
-    backlinks = backlinks.filter(_0, _1, title) => {
+    backlinks = backlinks.filter((_0, _1, title) => {
       return pagesChecked.indexOf(title) == -1
     })
     pagesToCheck.conct(backlinks)

--- a/spihelper.js
+++ b/spihelper.js
@@ -2470,6 +2470,32 @@ async function spiHelperGetInvestigationSectionIDs () {
 }
 
 /**
+ * Get SPI page backlinks to this SPI page.
+ * Used to fix double redirects when merging cases.
+ * 
+ */
+function spiHelperGetSPIBacklinks () {
+  // Only looking for enwiki backlinks
+  const api = new mw.Api()
+  try {
+    const response = await api.get({
+      action: "query",
+      format: "json",
+      list: "backlinks",
+      bltitle: spiHelperPageName,
+      blnamespace: "4",
+      bldir: "ascending",
+      blfilterredir: "nonredirects"
+    })
+    return response.query.backlinks.filter((pageid, ns, title) => {
+      return title.startsWith("Wikipedia:Sockpuppet investigations/") && !title.startsWith("Wikipedia:Sockpuppet investigations/SPI/") && !title.match("Wikipedia:Sockpuppet investigations/.*/Archive.*")
+    })
+  } catch (error) {
+    return []
+  }
+}
+
+/**
  * Pretty obvious - gets the name of the archive. This keeps us from having to regen it
  * if we rename the case
  *

--- a/spihelper.js
+++ b/spihelper.js
@@ -2507,7 +2507,7 @@ async function spiHelperGetSPIBacklinks (casePageName) {
       blfilterredir: 'nonredirects'
     })
     return response.query.backlinks.filter((pageid, ns, title) => {
-      return title.startsWith("Wikipedia:Sockpuppet investigations/") && !title.startsWith("Wikipedia:Sockpuppet investigations/SPI/") && !title.match("Wikipedia:Sockpuppet investigations/.*/Archive.*")
+      return title.startsWith('Wikipedia:Sockpuppet investigations/') && !title.startsWith('Wikipedia:Sockpuppet investigations/SPI/') && !title.match('Wikipedia:Sockpuppet investigations/.*/Archive.*')
     })
   } catch (error) {
     return []

--- a/spihelper.js
+++ b/spihelper.js
@@ -1517,21 +1517,21 @@ async function spiHelperPostRenameCleanup (oldCasePage) {
   const oldCaseName = oldCasePage.replace(/Wikipedia:Sockpuppet investigations\//g, '')
 
   // Update previous SPI redirects to this location
-  let pagesChecked = []
-  let pagesToCheck = [oldCasePage]
+  const pagesChecked = []
+  const pagesToCheck = [oldCasePage]
   let currentPageToCheck = null
-  while (pagesToCheck.length != 0) {
+  while (pagesToCheck.length !== 0) {
     currentPageToCheck = pagesToCheck.pop()
     let backlinks = await spiHelperGetSPIBacklinks(currentPageToCheck)
     backlinks = backlinks.filter((_0, _1, title) => {
-      return spiHelperParseArchiveNotice(title).username == currentPageToCheck.replace(/Wikipedia:Sockpuppet investigations\//g, '')
+      return spiHelperParseArchiveNotice(title).username === currentPageToCheck.replace(/Wikipedia:Sockpuppet investigations\//g, '')
     })
     backlinks.forEach((_0, _1, title) => {
       spiHelperEditPage(title, replacementArchiveNotice, 'Updating case following page move', false, spiHelperSettings.watchCase, spiHelperSettings.watchCaseExpiry)
     })
     pagesChecked.append(currentPageToCheck)
     backlinks = backlinks.filter((_0, _1, title) => {
-      return pagesChecked.indexOf(title) == -1
+      return pagesChecked.indexOf(title) === -1
     })
     pagesToCheck.conct(backlinks)
   }
@@ -2492,20 +2492,19 @@ async function spiHelperGetInvestigationSectionIDs () {
 /**
  * Get SPI page backlinks to this SPI page.
  * Used to fix double redirects when merging cases.
- * 
  */
 async function spiHelperGetSPIBacklinks (casePageName) {
   // Only looking for enwiki backlinks
   const api = new mw.Api()
   try {
     const response = await api.get({
-      action: "query",
-      format: "json",
-      list: "backlinks",
+      action: 'query',
+      format: 'json',
+      list: 'backlinks',
       bltitle: casePageName,
-      blnamespace: "4",
-      bldir: "ascending",
-      blfilterredir: "nonredirects"
+      blnamespace: '4',
+      bldir: 'ascending',
+      blfilterredir: 'nonredirects'
     })
     return response.query.backlinks.filter((pageid, ns, title) => {
       return title.startsWith("Wikipedia:Sockpuppet investigations/") && !title.startsWith("Wikipedia:Sockpuppet investigations/SPI/") && !title.match("Wikipedia:Sockpuppet investigations/.*/Archive.*")

--- a/spihelper.js
+++ b/spihelper.js
@@ -1522,7 +1522,7 @@ async function spiHelperPostRenameCleanup (oldCasePage) {
   let currentPageToCheck = null
   while (pagesToCheck.length != 0) {
     currentPageToCheck = pagesToCheck.pop()
-    let backlinks = spiHelperGetSPIBacklinks(currentPageToCheck)
+    let backlinks = await spiHelperGetSPIBacklinks(currentPageToCheck)
     backlinks = backlinks.filter((_0, _1, title) => {
       return spiHelperParseArchiveNotice(title).username == currentPageToCheck.replace(/Wikipedia:Sockpuppet investigations\//g, '')
     })
@@ -2494,7 +2494,7 @@ async function spiHelperGetInvestigationSectionIDs () {
  * Used to fix double redirects when merging cases.
  * 
  */
-function spiHelperGetSPIBacklinks (casePageName) {
+async function spiHelperGetSPIBacklinks (casePageName) {
   // Only looking for enwiki backlinks
   const api = new mw.Api()
   try {


### PR DESCRIPTION
If a full SPI case is moved more than once the first SPI redirect is not updated to the name of the case after the second move. This patch adds code which goes back through the backlinks of the old case page name and looks for previous case names. If it finds any now double (or more) SPI redirect it fixes them to point to the new case. Fixes #28 