### PR TITLE
Fixes for running on archives

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -2692,7 +2692,7 @@ async function spiHelperSetCheckboxesBySection () {
     let casestatus = ''
     if (result) {
       casestatus = result[1]
-    } else {
+    } else if (!spiHelperIsThisPageAnArchive) {
       $warningText.append($('<b>').text(`Can't find case status in ${spiHelperSectionName}!`))
       $warningText.show()
     }
@@ -2715,6 +2715,10 @@ async function spiHelperSetCheckboxesBySection () {
     $('#spiHelper_moveLabel', $topView).html('Move case section (<span title="You probably want to move the full case, ' +
       'select All Sections instead of a specific date in the drop-down"' +
       'class="rt-commentedText spihelper-hovertext"><b>READ ME FIRST</b></span>)')
+  }
+  // Only show options suitable for the archive subpage when running on the archives
+  if (spiHelperIsThisPageAnArchive) {
+    $('.spiHelper_notOnArchive', $topView).hide()
   }
 }
 

--- a/spihelper.js
+++ b/spihelper.js
@@ -616,6 +616,13 @@ async function spiHelperGenerateForm () {
     $('#spiHelper_spiMgmtView', $actionView).hide()
   }
 
+  if (!spiHelperActionsSelected.Close) {
+    $('#spiHelper_closeView', $actionView).hide()
+  }
+  if (!spiHelperActionsSelected.Archive) {
+    $('#spiHelper_archiveView', $actionView).hide()
+  }
+
   if (spiHelperActionsSelected.Block) {
     if (spiHelperIsAdmin()) {
       $('#spiHelper_blockTagHeader', $actionView).text('Blocking and tagging socks')
@@ -709,9 +716,6 @@ async function spiHelperGenerateForm () {
   } else {
     $('#spiHelper_blockTagView', $actionView).hide()
   }
-  if (!spiHelperActionsSelected.Close) {
-    $('#spiHelper_closeView', $actionView).hide()
-  }
   if (spiHelperActionsSelected.Rename) {
     if (spiHelperSectionId) {
       $('#spiHelper_moveHeader', $actionView).text('Move section "' + spiHelperSectionName + '"')
@@ -720,10 +724,6 @@ async function spiHelperGenerateForm () {
     }
   } else {
     $('#spiHelper_moveView', $actionView).hide()
-  }
-
-  if (!spiHelperActionsSelected.Archive) {
-    $('#spiHelper_archiveView', $actionView).hide()
   }
 
   // Only give the option to comment if we selected a specific section and we are not running on an archive subpage


### PR DESCRIPTION
Fixes issue with patch #81 where the spiHelperSetCheckboxesBySection function would show the options hidden. Also don't show the red error message for no case status if working on the archives.