### PR TITLE
If no archive notice is found don't error out

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -314,7 +314,7 @@ async function spiHelperInit () {
     if (pagetext.indexOf('__TOC__') === -1) {
       pagetext = '<noinclude>__TOC__</noinclude>\n' + pagetext
     }
-    await spiHelperEditPage(spiHelperPageName, pagetext, 'Adding archive notice', false, spiHelperSettings.watchCase, watchExpiry = spiHelperSettings.watchCaseExpiry)
+    await spiHelperEditPage(spiHelperPageName, pagetext, 'Adding archive notice', false, spiHelperSettings.watchCase, spiHelperSettings.watchCaseExpiry)
   }
 
   // Next, modify what's displayed

--- a/spihelper.js
+++ b/spihelper.js
@@ -297,12 +297,15 @@ async function spiHelperInit () {
   // First, insert the template text
   displayMessage(spiHelperTopViewHTML)
 
-  if(spiHelperArchiveNoticeParams.username === null) {
+  // Narrow search scope
+  const $topView = $('#spiHelper_topViewDiv', document)
+
+  if (spiHelperArchiveNoticeParams.username === null) {
     // No archive notice was found
     const $warningText = $('#spiHelper_warning', $topView)
     $warningText.show()
     $warningText.append($('<b>').text('Can\'t find archivenotice template! Automatically adding the archive notice to the page.'))
-    newArchiveNotice = spiHelperMakeNewArchiveNotice(spiHelperCaseName, {xwiki: false, deny: false, notalk: false})
+    const newArchiveNotice = spiHelperMakeNewArchiveNotice(spiHelperCaseName, { xwiki: false, deny: false, notalk: false })
     let pagetext = await spiHelperGetPageText(spiHelperPageName, false)
     if (spiHelperPriorCasesRegex.exec(pagetext) === null) {
       pagetext = '{{SPIpriorcases}}\n' + pagetext
@@ -311,11 +314,8 @@ async function spiHelperInit () {
     if (pagetext.indexOf('__TOC__') === -1) {
       pagetext = '<noinclude>__TOC__</noinclude>\n' + pagetext
     }
-    await spiHelperEditPage(spiHelperPageName, pagetext, "Adding archive notice", false, spiHelperSettings.watchCase, watchExpiry = spiHelperSettings.watchCaseExpiry)
+    await spiHelperEditPage(spiHelperPageName, pagetext, 'Adding archive notice', false, spiHelperSettings.watchCase, watchExpiry = spiHelperSettings.watchCaseExpiry)
   }
-
-  // Narrow search scope
-  const $topView = $('#spiHelper_topViewDiv', document)
 
   // Next, modify what's displayed
   // Set the block selection label based on whether or not the user is an admin
@@ -3058,8 +3058,8 @@ async function spiHelperParseArchiveNotice (page) {
   const pagetext = await spiHelperGetPageText(page, false)
   const match = spiHelperArchiveNoticeRegex.exec(pagetext)
   if (match === null) {
-    console.error("Missing archive notice")
-    return {username: null, deny: null, xwiki: null, notalk: null}
+    console.error('Missing archive notice')
+    return { username: null, deny: null, xwiki: null, notalk: null }
   }
   const username = match[1]
   let deny = false

--- a/spihelper.js
+++ b/spihelper.js
@@ -297,6 +297,23 @@ async function spiHelperInit () {
   // First, insert the template text
   displayMessage(spiHelperTopViewHTML)
 
+  if(spiHelperArchiveNoticeParams.username === null) {
+    // No archive notice was found
+    const $warningText = $('#spiHelper_warning', $topView)
+    $warningText.show()
+    $warningText.append($('<b>').text('Can\'t find archivenotice template!'))
+    newArchiveNotice = spiHelperMakeNewArchiveNotice(spiHelperCaseName, {xwiki: false, deny: false, notalk: false})
+    let pagetext = await spiHelperGetPageText(spiHelperPageName, false)
+    if (spiHelperPriorCasesRegex.exec(pagetext) === null) {
+      pagetext = '{{SPIpriorcases}}\n' + pagetext
+    }
+    pagetext = newArchiveNotice + '\n' + pagetext
+    if (pagetext.indexOf('__TOC__') === -1) {
+      pagetext = '<noinclude>__TOC__</noinclude>\n' + pagetext
+    }
+    await spiHelperEditPage(spiHelperPageName, pagetext, "Adding archive notice", false, spiHelperSettings.watchCase, watchExpiry = spiHelperSettings.watchCaseExpiry)
+  }
+
   // Narrow search scope
   const $topView = $('#spiHelper_topViewDiv', document)
 
@@ -3040,6 +3057,10 @@ function spiHelperNormalizeUsername (username) {
 async function spiHelperParseArchiveNotice (page) {
   const pagetext = await spiHelperGetPageText(page, false)
   const match = spiHelperArchiveNoticeRegex.exec(pagetext)
+  if (match === null) {
+    console.error("Missing archive notice")
+    return {username: null, deny: null, xwiki: null, notalk: null}
+  }
   const username = match[1]
   let deny = false
   let xwiki = false

--- a/spihelper.js
+++ b/spihelper.js
@@ -301,7 +301,7 @@ async function spiHelperInit () {
     // No archive notice was found
     const $warningText = $('#spiHelper_warning', $topView)
     $warningText.show()
-    $warningText.append($('<b>').text('Can\'t find archivenotice template!'))
+    $warningText.append($('<b>').text('Can\'t find archivenotice template! Automatically adding the archive notice to the page.'))
     newArchiveNotice = spiHelperMakeNewArchiveNotice(spiHelperCaseName, {xwiki: false, deny: false, notalk: false})
     let pagetext = await spiHelperGetPageText(spiHelperPageName, false)
     if (spiHelperPriorCasesRegex.exec(pagetext) === null) {


### PR DESCRIPTION
If no archive notice is found by spiHelperParseArchiveNotice the code ignores this and goes on to try and get the username from the result of the regex. If no match was found, null is returned so accessing the 2nd element of null will give an error. As such if the result is null there is no archive notice. The code I've written in case of no detected archive notice returns the archive notice type with the values set to null, as opposed to empty, as some code relies on this format being returned. Using null for these cases still works as intended. Fixes #75 
Also added code to generate an archive notice to add to the page if it doesn't exist (along with __TOC__ and {{SPIpriorcases}} if they are not there). A warning will also be visually shown to say that it was added automatically.