### PR TITLE
Keep existing protection after history merge

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -1823,7 +1823,7 @@ async function spiHelperMoveCase (target) {
       } else if (newPageNameEntry.length > 0) {
         newProtectionValues.append(newPageNameEntry[0])
       } else {
-        console.error("Invalid protection type given by API")
+        // No protection with this type on either page, so simply return to look at the next type.
         return
       }
     })

--- a/spihelper.js
+++ b/spihelper.js
@@ -1797,7 +1797,7 @@ async function spiHelperMoveCase (target) {
       let oldPageNameEntry = oldPageNameProtection.filter((dict) => { return dict.type === type })
       let newPageNameEntry = newPageNameProtection.filter((dict) => { return dict.type === type })
       if (oldPageNameEntry.length > 0 && newPageNameEntry.length > 0) {
-        const newProtectionDict = { type: oldEntry.type }
+        const newProtectionDict = { type: oldPageNameEntry.type }
         oldPageNameEntry = oldPageNameEntry[0]
         newPageNameEntry = newPageNameEntry[0]
         if (newPageNameEntry.expiry === 'infinity' || oldPageNameEntry.expiry === 'infinity' || newPageNameEntry.expiry === 'infinite' || oldPageNameEntry.expiry === 'infinite') {
@@ -1810,7 +1810,7 @@ async function spiHelperMoveCase (target) {
         const oldPageNameEntryLevelIndex = siteProtectionInformation.levels.indexOf(oldPageNameEntry.level)
         const newPageNameEntryLevelIndex = siteProtectionInformation.levels.indexOf(newPageNameEntry.level)
         if (oldPageNameEntryLevelIndex === -1 || newPageNameEntryLevelIndex === -1) {
-          console.error("Invalid protection information provided from API")
+          console.error('Invalid protection information provided from API')
           return
         } else if (oldPageNameEntryLevelIndex > newPageNameEntryLevelIndex) {
           newProtectionDict.push({ level: oldPageNameEntry.level })
@@ -1822,18 +1822,15 @@ async function spiHelperMoveCase (target) {
         newProtectionValues.append(oldPageNameEntry[0])
       } else if (newPageNameEntry.length > 0) {
         newProtectionValues.append(newPageNameEntry[0])
-      } else {
-        // No protection with this type on either page, so simply return to look at the next type.
-        return
       }
     })
     // Now handle pending changes protection
     const oldPageNameStabilisation = spiHelperGetStabilisationSettings(oldPageName)
     const newPageNameStabilisation = spiHelperGetStabilisationSettings(spiHelperPageName)
-    const newStabilisationSettings = {protection_level: ''}
+    let newStabilisationSettings = { protection_level: '' }
     if (oldPageNameStabilisation !== false && newPageNameStabilisation !== false) {
       // Pending changes is used on both pages
-      if (newPageNameEntry.protection_expiry === 'infinity' || oldPageNameStabilisation.protection_expiry === 'infinity' || newPageNameStabilisation.protection_expiry === 'infinite' || oldPageNameStabilisation.protection_expiry === 'infinite') {
+      if (newPageNameStabilisation.protection_expiry === 'infinity' || oldPageNameStabilisation.protection_expiry === 'infinity' || newPageNameStabilisation.protection_expiry === 'infinite' || oldPageNameStabilisation.protection_expiry === 'infinite') {
         newStabilisationSettings.push({ protection_expiry: 'infinite' })
       } else if (newPageNameStabilisation.protection_expiry < oldPageNameStabilisation.expiry) {
         newStabilisationSettings.push({ protection_expiry: oldPageNameStabilisation.protection_expiry })
@@ -1843,7 +1840,7 @@ async function spiHelperMoveCase (target) {
       const oldPageNameEntryLevelIndex = siteProtectionInformation.levels.indexOf(oldPageNameStabilisation.protection_level)
       const newPageNameEntryLevelIndex = siteProtectionInformation.levels.indexOf(newPageNameStabilisation.protection_level)
       if (oldPageNameEntryLevelIndex === -1 || newPageNameEntryLevelIndex === -1) {
-        console.error("Invalid protection information provided from API")
+        console.error('Invalid protection information provided from API')
         return
       } else if (oldPageNameEntryLevelIndex > newPageNameEntryLevelIndex) {
         newStabilisationSettings.push({ level: oldPageNameStabilisation.protection_level })
@@ -2673,8 +2670,7 @@ async function spiHelperGetStabilisationSettings (casePageName) {
     const entry = response.query.pages[Object.keys(response.query.pages)[0]]
     if ('flagged' in entry) {
       return entry.flagged
-    }
-    else {
+    } else {
       return false
     }
   } catch (error) {
@@ -2685,11 +2681,11 @@ async function spiHelperGetStabilisationSettings (casePageName) {
 async function spiHelperProtectPage (casePageName, protections) {
   // Only lookint to protect pages on enwiki
 
-  const activeOpKey = 'protect_' + title
+  const activeOpKey = 'protect_' + casePageName
   spiHelperActiveOperations.set(activeOpKey, 'running')
 
   const $statusLine = $('<li>').appendTo($('#spiHelper_status', document))
-  const $link = $('<a>').attr('href', mw.util.getUrl(title)).attr('title', title).text(title)
+  const $link = $('<a>').attr('href', mw.util.getUrl(casePageName)).attr('title', casePageName).text(casePageName)
   $statusLine.html('Protecting ' + $link.prop('outerHTML'))
 
   const api = new mw.Api()
@@ -2698,10 +2694,10 @@ async function spiHelperProtectPage (casePageName, protections) {
     let expiryinfo = ''
     protections.forEach((dict) => {
       if (protectlevelinfo !== '') {
-        protectlevelinfo = protectlevelinfo + "|"
-        expiryinfo = expiryinfo + "|"
+        protectlevelinfo = protectlevelinfo + '|'
+        expiryinfo = expiryinfo + '|'
       }
-      protectlevelinfo = protectlevelinfo + dict.type + "=" + dict.level
+      protectlevelinfo = protectlevelinfo + dict.type + '=' + dict.level
       expiryinfo = expiryinfo + dict.expiry
     })
     await api.postWithToken('csrf', {
@@ -2720,10 +2716,10 @@ async function spiHelperProtectPage (casePageName, protections) {
   }
 }
 
-async function spiHelperConfigurePendingChanges (casePageName, protection_level, protection_expiry) {
+async function spiHelperConfigurePendingChanges (casePageName, protectionLevel, protectionExpiry) {
   // Only lookint to protect pages on enwiki
 
-  const activeOpKey = 'stabilize_' + title
+  const activeOpKey = 'stabilize_' + casePageName
   spiHelperActiveOperations.set(activeOpKey, 'running')
 
   const api = new mw.Api()
@@ -2732,8 +2728,8 @@ async function spiHelperConfigurePendingChanges (casePageName, protection_level,
       action: 'stabilize',
       format: 'json',
       titles: casePageName,
-      protectlevel: protection_level,
-      expiry: protection_expiry,
+      protectlevel: protectionLevel,
+      expiry: protectionExpiry,
       reason: 'Restoring pending changes protection after history merge'
     })
     spiHelperActiveOperations.set(activeOpKey, 'success')

--- a/spihelper.js
+++ b/spihelper.js
@@ -2557,6 +2557,32 @@ async function spiHelperGetSPIBacklinks (casePageName) {
 }
 
 /**
+ * Get the page protection level for a SPI page.
+ * Used to keep the protection level after a history merge
+ */
+async function spiHelperGetProtectionInformation (casePageName) {
+  // Only looking for enwiki protection information
+  const api = new mw.Api()
+  try {
+    const response = await api.get({
+      action: 'query',
+      format: 'json',
+      prop: 'info|flagged',
+      titles: casePageName,
+      inprop: 'protection'
+    })
+    const entry = response.query.pages[Object.keys(response.query.pages)[0]]
+    if ('flagged' in entry) {
+      return entry.protection.concat([{ type: 'flagged', protection_level: entry.flagged.protection_level, protection_expiry: entry.flagged.protection_expiry}])
+    } else {
+      return entry.protection
+    }
+  } catch (error) {
+    return []
+  }
+}
+
+/**
  * Pretty obvious - gets the name of the archive. This keeps us from having to regen it
  * if we rename the case
  *

--- a/spihelper.js
+++ b/spihelper.js
@@ -1788,7 +1788,23 @@ async function spiHelperMoveCase (target) {
     // Now get existing protection levels on the target and existing page.
     const oldPageNameProtection = spiHelperGetProtectionInformation(oldPageName)
     const newPageNameProtection = spiHelperGetProtectionInformation(spiHelperPageName)
-    
+    /* TODO: Needs work
+    const combinedProtectionInformation = []
+    const combinedProtectionTypes = {}
+    const oldPageNameProtectionTypes = {}
+    const newPageNameProtectionTypes = {}
+    oldPageNameProtection.forEach((dict) => {
+      oldPageNameProtectionTypes.push({ dict.type: dict })
+    })
+    newPageNameProtection.forEach((dict) => {
+      newPageNameProtectionTypes.push({ dict.type: dict })
+    })
+    Object.keys(oldPageNameProtectionTypes).forEach((type) => {
+      if (type in Object.keys(newPageNameProtectionTypes)) {
+        oldPageNameProtection
+      }
+    }) */
+
     // Ignore warnings on the move, we're going to get one since we're stomping an existing page
     await spiHelperDeletePage(spiHelperPageName, 'Deleting as part of case merge')
     await spiHelperMovePage(oldPageName, spiHelperPageName, 'Merging case to [[' + spiHelperGetInterwikiPrefix() + spiHelperPageName + ']]', true)


### PR DESCRIPTION
This patch adds code which allows spiHelper to get protection information, stabilisation information (pending changes), protect pages and also configure stabilisation. These API functions are used when history merging as deleting pages removes existing protection which leaves SPI pages with protection unprotected unless manually restored. The code also chooses the highest possible settings for the protection / pending changes by choosing the longest expiry and highest protection level already being used on either of the pages.

Fixes #21 