### PR TITLE
Allow SPI helper to be run on multiple cases at once

### DIFF
--- a/spihelper.css
+++ b/spihelper.css
@@ -19,5 +19,5 @@
 }
 
 .spiHelper_forSomeCases {
-    display:none;
+    display: none;
 }

--- a/spihelper.css
+++ b/spihelper.css
@@ -17,3 +17,7 @@
 .spihelper-widthlimit {
     width: 10vw;
 }
+
+.spiHelper_forSomeCases {
+    display:none;
+}

--- a/spihelper.js
+++ b/spihelper.js
@@ -537,10 +537,10 @@ const spiHelperActionViewHTML = `
 // eslint-disable-next-line no-unused-vars
 async function spiHelperGenerateForm () {
   'use strict'
-  const $warningText = $('#spiHelper_warning', $actionView)
-  $warningText.hide()
   spiHelperUserCount = 0
   const $topView = $('#spiHelper_topViewDiv', document)
+  const $warningText = $('#spiHelper_warning', $topView)
+  $warningText.hide()
   spiHelperActionsSelected.Case_act = $('#spiHelper_Case_Action', $topView).prop('checked')
   spiHelperActionsSelected.Block = $('#spiHelper_BlockTag', $topView).prop('checked')
   spiHelperActionsSelected.Note = $('#spiHelper_Comment', $topView).prop('checked')
@@ -3087,8 +3087,8 @@ async function spiHelperUpdateCaseActions () {
   const $multipleSectionSelect = $('#spiHelper_multipleSectionSelect', $topView)
   const $warningText = $('#spiHelper_warning', $topView)
   $warningText.show()
-  const activeCaseStatuses = $('input', $multipleSectionSelect).filter(() => { return $(this).prop('checked') })
-  console.log(activeCaseStatuses)
+  const $activeCaseStatuses = $('input', $multipleSectionSelect).filter(() => { return $(this).prop('checked') })
+  console.log($activeCaseStatuses)
   const $archiveBox = $('#spiHelper_Archive', $topView)
   const $closeBox = $('#spiHelper_Close', $topView)
   $archiveBox.prop('disabled', true)

--- a/spihelper.js
+++ b/spihelper.js
@@ -1626,8 +1626,8 @@ async function spiHelperPerformActions () {
       editsummary = ''
     }
     return true
-  }
-  
+  })
+
   if (spiHelperActionsSelected.Archive) {
     // Archive the case
     if (spiHelperCaseModeSelected.all) {

--- a/spihelper.js
+++ b/spihelper.js
@@ -357,9 +357,9 @@ async function spiHelperInit () {
   for (let i = 0; i < spiHelperCaseSections.length; i++) {
     const s = spiHelperCaseSections[i]
     $('<option>').val(s.index).text(s.line).appendTo($sectionSelect)
-    let $li = $('<li>').attr("id", "spiHelper_li_" + s.index.toString()).appendTo($multipleSectionSelect)
-    $('<input type="checkbox">').val(s.index).attr("id", "spiHelper_input_" + s.index.toString()).appendTo($li)
-    $('<label>').text(s.line).attr('for', "spiHelper_input_" + s.index.toString()).appendTo($li)
+    const $li = $('<li>').attr('id', 'spiHelper_li_' + s.index.toString()).appendTo($multipleSectionSelect)
+    $('<input>').attr('type', 'checkbox').val(s.index).attr('id', 'spiHelper_input_' + s.index.toString()).appendTo($li)
+    $('<label>').text(s.line).attr('for', 'spiHelper_input_' + s.index.toString()).appendTo($li)
   }
   // Selected-sections selector. Used to change the case status, close or archive selected sections all at once.
   $('<option>').val('some').text('Selected Sections').appendTo($sectionSelect)
@@ -2962,7 +2962,7 @@ async function spiHelperSetCheckboxesBySection () {
     $('#spiHelper_moveLabel', $topView).html('Move case section<span class="spiHelper_forSomeCases">s</span> (<span title="You probably want to move the full case, ' +
       'select All Sections instead of a specific date in the drop-down"' +
       'class="rt-commentedText spihelper-hovertext"><b>READ ME FIRST</b></span>)')
-    
+
     // Update the options so that they are not plural
     $('.spiHelper_forSomeCases', $topView).hide()
     $('.spiHelper_notForSomeCases', $topView).show()

--- a/spihelper.js
+++ b/spihelper.js
@@ -1462,8 +1462,9 @@ async function spiHelperPerformActions () {
   }
 
   if (spiHelperActionsSelected.SpiMgmt) {
+    let sectionText = await spiHelperGetPageText(spiHelperPageName, true)
     const newArchiveNotice = spiHelperMakeNewArchiveNotice(spiHelperCaseName, spiHelperArchiveNoticeParams)
-    let sectionText = sectionText.replace(spiHelperArchiveNoticeRegex, newArchiveNotice)
+    sectionText = sectionText.replace(spiHelperArchiveNoticeRegex, newArchiveNotice)
     if (editsummary) {
       editsummary += ', update archivenotice'
     } else {
@@ -1648,7 +1649,7 @@ async function spiHelperPerformActions () {
       let failedAtIndex = spiHelperSectionId.length + 1
       spiHelperSectionId.every(await async function (sectionId, index) {
         logMessage += '\n** Archived section'
-        let archivetext = await spiHelperGetArchiveTextForCaseSection(sectionId)
+        const archivetext = await spiHelperGetArchiveTextForCaseSection(sectionId)
         const postExpandPercent =
           (await spiHelperGetPostExpandSize(spiHelperPageName, sectionId) +
           await spiHelperGetPostExpandSize(spiHelperGetArchiveName())) /
@@ -1664,7 +1665,7 @@ async function spiHelperPerformActions () {
           await spiHelperMovePage(spiHelperGetArchiveName(), newArchiveName, 'Moving archive to avoid exceeding post expand size limit', false)
           await spiHelperEditPage(spiHelperGetArchiveName(), '', 'Removing redirect', false, 'nochange')
         }
-        if(!await spiHelperSaveToArchive(archiveText)) {
+        if(!await spiHelperSaveToArchive(archivetext)) {
           failedAtIndex = index
           return false
         }
@@ -1892,10 +1893,10 @@ async function spiHelperSaveToArchive (archivetext) {
 
 async function spiHelperBlankCaseSection (sectionId) {
   'use strict'
-   await spiHelperEditPage(spiHelperPageName, '', 'Archiving case section to [[' + spiHelperGetInterwikiPrefix() + spiHelperGetArchiveName() + ']]',
-     false, spiHelperSettings.watchCase, spiHelperSettings.watchCaseExpiry, spiHelperStartingRevID, sectionId)
-   // Update to the latest revision ID
-   spiHelperStartingRevID = await spiHelperGetPageRev(spiHelperPageName)
+  await spiHelperEditPage(spiHelperPageName, '', 'Archiving case section to [[' + spiHelperGetInterwikiPrefix() + spiHelperGetArchiveName() + ']]',
+    false, spiHelperSettings.watchCase, spiHelperSettings.watchCaseExpiry, spiHelperStartingRevID, sectionId)
+  // Update to the latest revision ID
+  spiHelperStartingRevID = await spiHelperGetPageRev(spiHelperPageName)
 }
 
 async function spiHelperGetArchiveTextForCaseSection (sectionId) {

--- a/spihelper.js
+++ b/spihelper.js
@@ -1644,7 +1644,7 @@ async function spiHelperPerformActions () {
       let failedAtIndex = spiHelperSectionId.length + 1
       spiHelperSectionId.every(await async function (sectionId, index) {
         logMessage += '\n** Archived section'
-        archivetext = await spiHelperGetArchiveTextForCaseSection(sectionId))
+        archivetext = await spiHelperGetArchiveTextForCaseSection(sectionId)
         const postExpandPercent =
           (await spiHelperGetPostExpandSize(spiHelperPageName, sectionId) +
           await spiHelperGetPostExpandSize(spiHelperGetArchiveName())) /
@@ -3178,6 +3178,7 @@ async function spiHelperUpdateCaseActions () {
   const $multipleSectionSelect = $('#spiHelper_multipleSectionSelect', $topView)
   const $warningText = $('#spiHelper_warning', $topView)
   $warningText.show()
+  $('#spiHelper_multipleSectionSelect', $topView).find('input').prop('disabled', false)
   const selectedSectionIds = $('#spiHelper_multipleSectionSelect', $topView).find('input').filter((index, element) => { return $(element).prop('checked') }).map((index, element) => { return $(element).val() }).get()
   console.log(selectedSectionIds)
   const $archiveBox = $('#spiHelper_Archive', $topView)
@@ -3215,17 +3216,17 @@ async function spiHelperUpdateCaseActions () {
 
     const isClosed = spiHelperCaseClosedRegex.test(casestatus)
 
-    if (!$archiveBox.prop('disabled') && !$closeBox.prop('disabled')) {
-      // If both are now enabled, we don't need to do further checks.
-      break
+    if ((!$archiveBox.prop('disabled') && !isClosed) || (!$closeBox.prop('disabled') && isClosed)) {
+      $('#spiHelper_multipleSectionSelect', $topView).find('input').each(function (element) {
+        if ($(element).value() === s.index) {
+          $(element).prop('disabled', true) 
+        }
+      })
     } else if (isClosed && $archiveBox.prop('disabled')) {
-      // If the selected options include archiving, then don't show this section in the list as it can't be archived.
       $archiveBox.prop('disabled', false)
       $archiveBox.prop('checked', true)
     } else if (!isClosed && $closeBox.prop('disabled')) {
-      // If the selected options include closing, then don't show this section in the list as it can't be closed.
       $closeBox.prop('disabled', false)
-      continue
     }
   }
 }

--- a/spihelper.js
+++ b/spihelper.js
@@ -747,6 +747,14 @@ async function spiHelperGenerateForm () {
   }
 
   if (spiHelperActionsSelected.Block) {
+    let pagetext = ''
+    if (spiHelperCaseModeSelected.some) {
+      for (let i=0; i < spiHelperSectionId.length; i++) {
+        pagetext = pagetext + await spiHelperGetPageText(spiHelperPageName, false, spiHelperSectionId[i])
+      }
+    } else {
+      pagetext = await spiHelperGetPageText(spiHelperPageName, false, spiHelperSectionId[0])
+    }
     if (spiHelperIsAdmin()) {
       $('#spiHelper_blockTagHeader', $actionView).text('Blocking and tagging socks')
     } else {
@@ -840,8 +848,10 @@ async function spiHelperGenerateForm () {
     $('#spiHelper_blockTagView', $actionView).hide()
   }
   if (spiHelperActionsSelected.Rename) {
-    if (spiHelperSectionId) {
+    if (spiHelperCaseModeSelected.single) {
       $('#spiHelper_moveHeader', $actionView).text('Move section "' + spiHelperSectionName + '"')
+    } else if (spiHelperCaseModeSelected.some) {
+      $('#spiHelper_moveHeader', $actionView).text('Move sections')
     } else {
       $('#spiHelper_moveHeader', $actionView).text('Move/merge full case')
     }
@@ -850,7 +860,7 @@ async function spiHelperGenerateForm () {
   }
 
   // Only give the option to comment if we selected a specific section and we are not running on an archive subpage
-  if (spiHelperSectionId && !spiHelperIsThisPageAnArchive) {
+  if (!spiHelperCaseModeSelected.all && !spiHelperIsThisPageAnArchive) {
     // generate the note prefixes
     /** @type {SelectOption[]} */
     const spiHelperNoteTemplates = [
@@ -879,6 +889,12 @@ async function spiHelperGenerateForm () {
     spiHelperGenerateSelect('spiHelper_cuSelect', spiHelperCUTemplates)
     $('#spiHelper_cuSelect', $actionView).on('change', function (e) {
       spiHelperInsertTextFromSelect($(e.target))
+    })
+    $('#spiHelper_duplicateComment', $actionView).on('change', function (e) {
+      $('#spiHelper_referenceComment', $actionView).prop('disabled', $(e.target).prop('checked'))
+    })
+    $('#spiHelper_referenceComment', $actionView).on('change', function (e) {
+      $('#spiHelper_duplicateComment', $actionView).prop('disabled', $(e.target).prop('checked'))
     })
     $('#spiHelper_previewLink', $actionView).on('click', function () {
       spiHelperPreviewText()

--- a/spihelper.js
+++ b/spihelper.js
@@ -367,7 +367,7 @@ async function spiHelperInit () {
     $('<option>').val(s.index).text(s.line).appendTo($sectionSelect)
     const $li = $('<li>').attr('id', 'spiHelper_li_' + s.index.toString()).appendTo($multipleSectionSelect)
     $('<input>').attr('type', 'checkbox').val(s.index).attr('id', 'spiHelper_input_' + s.index.toString()).appendTo($li)
-    $li.append(" ")
+    $li.append(' ')
     $('<label>').text(s.line).attr('for', 'spiHelper_input_' + s.index.toString()).appendTo($li)
   }
   // Selected-sections selector. Used to change the case status, close or archive selected sections all at once. Don't show if there are no cases
@@ -1085,14 +1085,14 @@ async function spiHelperPerformActions () {
   if (spiHelperCaseModeSelected.single || spiHelperSectionId.length < 2) {
     logMessage += ' (section ' + spiHelperSectionName[0] + ')'
   } else if (spiHelperCaseModeSelected.some) {
-    logMessage += ' (sections ' + spiHelperSectionName.reduce((text, sectionName, i) => { 
+    logMessage += ' (sections ' + spiHelperSectionName.reduce((text, sectionName, i) => {
       return text + (spiHelperSectionName.length - 1 > i ? ', ' : ' and ') + sectionName
     })
   } else {
     logMessage += ' (full case)'
   }
   logMessage += ' ~~~~~'
- 
+
   if (spiHelperActionsSelected.Block) {
     let sockmaster = ''
     let altmaster = ''
@@ -1460,16 +1460,21 @@ async function spiHelperPerformActions () {
       }
     }
   }
- 
+
   if (spiHelperActionsSelected.SpiMgmt) {
     const newArchiveNotice = spiHelperMakeNewArchiveNotice(spiHelperCaseName, spiHelperArchiveNoticeParams)
-    sectionText = sectionText.replace(spiHelperArchiveNoticeRegex, newArchiveNotice)
+    let sectionText = sectionText.replace(spiHelperArchiveNoticeRegex, newArchiveNotice)
     if (editsummary) {
       editsummary += ', update archivenotice'
     } else {
       editsummary = 'Update archivenotice'
     }
     logMessage += '\n** Updated archivenotice'
+    const editResult = await spiHelperEditPage(spiHelperPageName, sectionText, editsummary, false,
+      spiHelperSettings.watchCase, spiHelperSettings.watchCaseExpiry, spiHelperStartingRevID, sectionId)
+    if (editResult) {
+      spiHelperStartingRevID = editResult.edit.newrevid
+    }
   }
 
   let sectionCount = await spiHelperGetSectionIDs().length
@@ -1640,11 +1645,10 @@ async function spiHelperPerformActions () {
     } else {
       logMessage += '\n** Archived cases'
       // Just archive the selected sections
-      let archivetext = ''
       let failedAtIndex = spiHelperSectionId.length + 1
       spiHelperSectionId.every(await async function (sectionId, index) {
         logMessage += '\n** Archived section'
-        archivetext = await spiHelperGetArchiveTextForCaseSection(sectionId)
+        let archivetext = await spiHelperGetArchiveTextForCaseSection(sectionId)
         const postExpandPercent =
           (await spiHelperGetPostExpandSize(spiHelperPageName, sectionId) +
           await spiHelperGetPostExpandSize(spiHelperGetArchiveName())) /
@@ -1872,7 +1876,7 @@ async function spiHelperArchiveCaseSection (sectionId) {
     await spiHelperBlankCaseSection(sectionId)
   }
 }
- 
+
 async function spiHelperSaveToArchive (archivetext) {
   const archiveSuccess = await spiHelperEditPage(spiHelperGetArchiveName(), archivetext,
     'Archiving case section from [[' + spiHelperGetInterwikiPrefix() + spiHelperPageName + ']]',
@@ -1885,7 +1889,7 @@ async function spiHelperSaveToArchive (archivetext) {
   }
   return true
 }
- 
+
 async function spiHelperBlankCaseSection (sectionId) {
   'use strict'
    await spiHelperEditPage(spiHelperPageName, '', 'Archiving case section to [[' + spiHelperGetInterwikiPrefix() + spiHelperGetArchiveName() + ']]',
@@ -1893,7 +1897,7 @@ async function spiHelperBlankCaseSection (sectionId) {
    // Update to the latest revision ID
    spiHelperStartingRevID = await spiHelperGetPageRev(spiHelperPageName)
 }
- 
+
 async function spiHelperGetArchiveTextForCaseSection (sectionId) {
   'use strict'
   let sectionText = await spiHelperGetPageText(spiHelperPageName, true, sectionId)
@@ -3107,7 +3111,7 @@ async function spiHelperSetCheckboxesBySection () {
     // Now work out if to enable/disable Close cases and Archive cases. If all cases are closed, then closed cases cannot be used. If all cases are not closed, then archive cases
     // cannot be used
     spiHelperUpdateCaseActions()
-    $('#spiHelper_multipleSectionSelect input', $topView).change(() => {
+    $('#spiHelper_multipleSectionSelect input', $topView).on('change', () => {
       spiHelperUpdateCaseActions()
     })
   } else if ($('#spiHelper_sectionSelect', $topView).val() === 'all') {
@@ -3178,7 +3182,7 @@ async function spiHelperUpdateCaseActions () {
   const $warningText = $('#spiHelper_warning', $topView)
   $warningText.show()
   $('#spiHelper_multipleSectionSelect', $topView).find('input').prop('disabled', false)
-  const selectedSectionIds = $('#spiHelper_multipleSectionSelect', $topView).find('input').filter((index, element) => { return $(element).prop('checked') }).map((index, element) => { return $(element).val() }).get()
+  const selectedSectionIds = $multipleSectionSelect.find('input').filter((index, element) => { return $(element).prop('checked') }).map((index, element) => { return $(element).val() }).get()
   console.log(selectedSectionIds)
   const $archiveBox = $('#spiHelper_Archive', $topView)
   const $closeBox = $('#spiHelper_Close', $topView)
@@ -3216,9 +3220,9 @@ async function spiHelperUpdateCaseActions () {
     const isClosed = spiHelperCaseClosedRegex.test(casestatus)
 
     if ((!$archiveBox.prop('disabled') && !isClosed) || (!$closeBox.prop('disabled') && isClosed)) {
-      $('#spiHelper_multipleSectionSelect', $topView).find('input').each(function (element) {
+      $multipleSectionSelect.find('input').each(function (element) {
         if ($(element).value() === s.index) {
-          $(element).prop('disabled', true) 
+          $(element).prop('disabled', true)
         }
       })
     } else if (isClosed && $archiveBox.prop('disabled')) {

--- a/spihelper.js
+++ b/spihelper.js
@@ -1666,10 +1666,9 @@ async function spiHelperPerformActions () {
         }
       })
       spiHelperSectionId.slice().reverse().forEach((sectionId, indexV2) => { // Reversed because this means that the yet to be processed sectionIDs won't have changed unless a non-tool edit is made in the iterim.
-        if (spiHelperSectionId.length - indexV2 >= failedAtIndex) {
-          continue
+        if (spiHelperSectionId.length - indexV2 < failedAtIndex) {
+          spiHelperBlankCaseSection(sectionId)
         }
-        spiHelperBlankCaseSection(sectionId)
       })
     }
   } else if (spiHelperActionsSelected.Rename && renameTarget) {

--- a/spihelper.js
+++ b/spihelper.js
@@ -1481,7 +1481,7 @@ async function spiHelperPerformActions () {
       // The section IDs that have already been processed will be still fine.
       spiHelperSectionId.forEach((sectionIdToModify, indexForModifyLoop) => {
         if (index < indexForModifyLoop) {
-          continue
+          return
         }
         spiHelperSectionId[indexForModifyLoop] = sectionIdToModify + (await spiHelperGetSectionIDs().length - sectionCount)
       })

--- a/spihelper.js
+++ b/spihelper.js
@@ -1479,7 +1479,7 @@ async function spiHelperPerformActions () {
       // or another editor making an edit to the page. If this is the latter it will be handled by baseRevId in spiHelperEditPage. If it is the former, then all that needs to done
       // is add the difference to every sectionId left to process (as the cases are worked on from the top down and archiving is done later).
       // The section IDs that have already been processed will be still fine.
-      spiHelperSectionId.forEach((sectionIdToModify, indexForModifyLoop) => {
+      spiHelperSectionId.forEach(await async function (sectionIdToModify, indexForModifyLoop) {
         if (index < indexForModifyLoop) {
           return
         }
@@ -1642,7 +1642,7 @@ async function spiHelperPerformActions () {
       // Just archive the selected sections
       let archivetext = ''
       let failedAtIndex = spiHelperSectionId.length + 1
-      spiHelperSectionId.every((sectionId, index) => {
+      spiHelperSectionId.every(await async function (sectionId, index) {
         logMessage += '\n** Archived section'
         archivetext = await spiHelperGetArchiveTextForCaseSection(sectionId))
         const postExpandPercent =
@@ -1679,7 +1679,7 @@ async function spiHelperPerformActions () {
       await spiHelperMoveCase(renameTarget)
     } else {
       // Option 2: this is a single-section(s) case move or merge
-      spiHelperSectionId.slice().reverse().forEach((sectionId) => { // Reversed for the same reason as why it was reversed for the archive code
+      spiHelperSectionId.slice().reverse().forEach(await async function (sectionId) { // Reversed for the same reason as why it was reversed for the archive code
         logMessage += '\n** moved section to ' + renameTarget
         await spiHelperMoveCaseSection(renameTarget, sectionId)
       }

--- a/spihelper.js
+++ b/spihelper.js
@@ -359,8 +359,8 @@ async function spiHelperInit () {
     spiHelperSetCheckboxesBySection()
   })
 
- const $multipleSectionSelect = $('#spiHelper_multipleSectionSelect', $topView) 
- // Add the dates to the selector
+  const $multipleSectionSelect = $('#spiHelper_multipleSectionSelect', $topView)
+  // Add the dates to the selector
   for (let i = 0; i < spiHelperCaseSections.length; i++) {
     const s = spiHelperCaseSections[i]
     $('<option>').val(s.index).text(s.line).appendTo($sectionSelect)
@@ -537,6 +537,8 @@ const spiHelperActionViewHTML = `
 // eslint-disable-next-line no-unused-vars
 async function spiHelperGenerateForm () {
   'use strict'
+  const $warningText = $('#spiHelper_warning', $actionView)
+  $warningText.hide()
   spiHelperUserCount = 0
   const $topView = $('#spiHelper_topViewDiv', document)
   spiHelperActionsSelected.Case_act = $('#spiHelper_Case_Action', $topView).prop('checked')
@@ -549,9 +551,9 @@ async function spiHelperGenerateForm () {
   spiHelperCaseModeSelected.some = $('#spiHelper_sectionSelect', $topView).val() === 'some'
   spiHelperCaseModeSelected.all = $('#spiHelper_sectionSelect', $topView).val() === 'all'
   spiHelperCaseModeSelected.single = !['all', 'some'].includes($('#spiHelper_sectionSelect', $topView).val())
-  let spiHelperSelectedCaseStatuses = new Set()
+  const spiHelperSelectedCaseStatuses = new Set()
   if (spiHelperCaseModeSelected.some) {
-    spiHelperSectionId = $('#spiHelper_multipleSectionSelect', $topView).find("input").filter((index, element) => { return $(element).prop('checked') }).map((index, element) => { return $(element).val() }).get()
+    spiHelperSectionId = $('#spiHelper_multipleSectionSelect', $topView).find('input').filter((index, element) => { return $(element).prop('checked') }).map((index, element) => { return $(element).val() }).get()
     console.log(spiHelperSectionId)
     for (let i = 0; i < spiHelperCaseSections.length; i++) {
       if (spiHelperSectionId.indexOf(spiHelperCaseSections[i].index) > 0) {
@@ -598,12 +600,9 @@ async function spiHelperGenerateForm () {
     spiHelperInit()
   })
 
-  const $warningText = $('#spiHelper_warning', $actionView)
-  $warningText.hide()
-
   if (spiHelperCaseModeSelected.some) {
-   $('.spiHelper_forSomeCases', $actionView).show()
-   $('.spiHelper_notForSomeCases', $actionView).hide()
+    $('.spiHelper_forSomeCases', $actionView).show()
+    $('.spiHelper_notForSomeCases', $actionView).hide()
   } else {
     $('.spiHelper_forSomeCases', $actionView).hide()
     $('.spiHelper_notForSomeCases', $actionView).show()
@@ -623,7 +622,7 @@ async function spiHelperGenerateForm () {
       cudecline: true,
       decline: true,
       cumoreinfo: true,
-      relist: true,
+      relist: true
     }
     spiHelperSelectedCaseStatuses.forEach((casestatus) => {
       const canAddCURequest = (casestatus === '' || /^(?:admin|moreinfo|cumoreinfo|hold|cuhold|clerk|open)$/i.test(casestatus))
@@ -749,7 +748,7 @@ async function spiHelperGenerateForm () {
   if (spiHelperActionsSelected.Block) {
     let pagetext = ''
     if (spiHelperCaseModeSelected.some) {
-      for (let i=0; i < spiHelperSectionId.length; i++) {
+      for (let i = 0; i < spiHelperSectionId.length; i++) {
         pagetext = pagetext + await spiHelperGetPageText(spiHelperPageName, false, spiHelperSectionId[i])
       }
     } else {
@@ -3086,44 +3085,46 @@ async function spiHelperSetCheckboxesBySection () {
 async function spiHelperUpdateCaseActions () {
   const $topView = $('#spiHelper_topViewDiv', document)
   const $multipleSectionSelect = $('#spiHelper_multipleSectionSelect', $topView)
-  const activeCaseStatuses = $('input', $multipleSectionSelect).filter(() => {return $(this).prop('checked')})
+  const $warningText = $('#spiHelper_warning', $topView)
+  $warningText.show()
+  const activeCaseStatuses = $('input', $multipleSectionSelect).filter(() => { return $(this).prop('checked') })
   console.log(activeCaseStatuses)
   const $archiveBox = $('#spiHelper_Archive', $topView)
   const $closeBox = $('#spiHelper_Close', $topView)
   $archiveBox.prop('disabled', true)
   $closeBox.prop('disabled', true)
   for (let i = 0; i < spiHelperCaseSections.length; i++) {
-   const s = spiHelperCaseSections[i]
-   const sectionText = await spiHelperGetPageText(spiHelperPageName, false, s.index)
-   if (!spiHelperSectionRegex.test(sectionText)) {
-     // Nothing to do here.
-     continue
-   }
-   const result = spiHelperCaseStatusRegex.exec(sectionText)
-   let casestatus = ''
-   if (result) {
-     casestatus = result[1]
-   } else if (!spiHelperIsThisPageAnArchive) {
-     $warningText.append($('<b>').text(`Can't find case status in ${spiHelperSectionName}!`))
-     $warningText.show()
-     continue
-   }
+    const s = spiHelperCaseSections[i]
+    const sectionText = await spiHelperGetPageText(spiHelperPageName, false, s.index)
+    if (!spiHelperSectionRegex.test(sectionText)) {
+      // Nothing to do here.
+      continue
+    }
+    const result = spiHelperCaseStatusRegex.exec(sectionText)
+    let casestatus = ''
+    if (result) {
+      casestatus = result[1]
+    } else if (!spiHelperIsThisPageAnArchive) {
+      $warningText.append($('<b>').text(`Can't find case status in ${spiHelperSectionName}!`))
+      $warningText.show()
+      continue
+    }
 
-   const isClosed = spiHelperCaseClosedRegex.test(casestatus)
+    const isClosed = spiHelperCaseClosedRegex.test(casestatus)
 
-   if (!$archiveBox.prop('disabled') && !$closeBox.prop('disabled')) {
-     // If both are now enabled, we don't need to do further checks.
-     break
-   } else if (isClosed && $archiveBox.prop('disabled')) {
-     // If the selected options include archiving, then don't show this section in the list as it can't be archived.
-     $archiveBox.prop('disabled', false)
-     $archiveBox.prop('checked', true)
-   } else if (!isClosed && $closeBox.prop('disabled')) {
-     // If the selected options include closing, then don't show this section in the list as it can't be closed.
-     $closeBox.prop('disabled', false)
-     continue
-   }
- }
+    if (!$archiveBox.prop('disabled') && !$closeBox.prop('disabled')) {
+      // If both are now enabled, we don't need to do further checks.
+      break
+    } else if (isClosed && $archiveBox.prop('disabled')) {
+      // If the selected options include archiving, then don't show this section in the list as it can't be archived.
+      $archiveBox.prop('disabled', false)
+      $archiveBox.prop('checked', true)
+    } else if (!isClosed && $closeBox.prop('disabled')) {
+      // If the selected options include closing, then don't show this section in the list as it can't be closed.
+      $closeBox.prop('disabled', false)
+      continue
+    }
+  }
 }
 
 /**
@@ -3251,7 +3252,7 @@ function spiHelperInsertNote (source) {
  *
  * @param {JQuery<HTMLElement>} source Select box that was changed
  */
-function spiHelperCaseActionUpdated (source) { //TODO: Add 'some' mode support
+function spiHelperCaseActionUpdated (source) { // TODO: Add 'some' mode support
   const $textBox = $('#spiHelper_CommentText', document)
   const oldText = $textBox.val().toString()
   let newTemplate = ''

--- a/spihelper.js
+++ b/spihelper.js
@@ -2783,7 +2783,7 @@ async function spiHelperGetInvestigationSectionIDs () {
   // sections (should all be level-3 headers)
   'use strict'
 
-  cosnt sections = await spiHelperGetSectionIDs()
+  const sections = await spiHelperGetSectionIDs()
   const dateSections = []
   for (let i = 0; i < sections.length; i++) {
     // TODO: also check for presence of spi case status

--- a/spihelper.js
+++ b/spihelper.js
@@ -1472,7 +1472,7 @@ async function spiHelperPerformActions () {
     }
     logMessage += '\n** Updated archivenotice'
     const editResult = await spiHelperEditPage(spiHelperPageName, sectionText, editsummary, false,
-      spiHelperSettings.watchCase, spiHelperSettings.watchCaseExpiry, spiHelperStartingRevID, sectionId)
+      spiHelperSettings.watchCase, spiHelperSettings.watchCaseExpiry, spiHelperStartingRevID)
     if (editResult) {
       spiHelperStartingRevID = editResult.edit.newrevid
     }
@@ -1665,7 +1665,7 @@ async function spiHelperPerformActions () {
           await spiHelperMovePage(spiHelperGetArchiveName(), newArchiveName, 'Moving archive to avoid exceeding post expand size limit', false)
           await spiHelperEditPage(spiHelperGetArchiveName(), '', 'Removing redirect', false, 'nochange')
         }
-        if(!await spiHelperSaveToArchive(archivetext)) {
+        if (!await spiHelperSaveToArchive(archivetext)) {
           failedAtIndex = index
           return false
         }

--- a/spihelper.js
+++ b/spihelper.js
@@ -1473,7 +1473,7 @@ async function spiHelperPerformActions () {
   }
 
   let sectionCount = await spiHelperGetSectionIDs().length
-  spiHelperSectionId.every((sectionId, index) => {
+  spiHelperSectionId.every(await async (sectionId, index) => {
     if (sectionCount !== await spiHelperGetSectionIDs().length) {
       // If total section count has changed since the last spiHelperEditPage call then this is either due to the comment section including a comment
       // or another editor making an edit to the page. If this is the latter it will be handled by baseRevId in spiHelperEditPage. If it is the former, then all that needs to done

--- a/spihelper.js
+++ b/spihelper.js
@@ -3222,7 +3222,7 @@ async function spiHelperUpdateCaseActions () {
 
     if ((!$archiveBox.prop('disabled') && !isClosed) || (!$closeBox.prop('disabled') && isClosed)) {
       $multipleSectionSelect.find('input').each(function (element) {
-        if ($(element).value() === s.index) {
+        if ($(element).val() === s.index) {
           $(element).prop('disabled', true)
         }
       })

--- a/spihelper.js
+++ b/spihelper.js
@@ -1681,7 +1681,7 @@ async function spiHelperPerformActions () {
       spiHelperSectionId.slice().reverse().forEach(await async function (sectionId) { // Reversed for the same reason as why it was reversed for the archive code
         logMessage += '\n** moved section to ' + renameTarget
         await spiHelperMoveCaseSection(renameTarget, sectionId)
-      }
+      })
     }
   }
   if (spiHelperSettings.log) {

--- a/spihelper.js
+++ b/spihelper.js
@@ -1473,7 +1473,7 @@ async function spiHelperPerformActions () {
   }
 
   let sectionCount = await spiHelperGetSectionIDs().length
-  spiHelperSectionId.every(await async (sectionId, index) => {
+  spiHelperSectionId.every(await async function (sectionId, index) {
     if (sectionCount !== await spiHelperGetSectionIDs().length) {
       // If total section count has changed since the last spiHelperEditPage call then this is either due to the comment section including a comment
       // or another editor making an edit to the page. If this is the latter it will be handled by baseRevId in spiHelperEditPage. If it is the former, then all that needs to done


### PR DESCRIPTION
This patch allows SPI helper to be run on multiple cases at once. It adds a selector option for "Selected Cases" to the date selector. If selected it shows a checkbox list of the cases allowing multiple to be selected. It automatically disables options based on the selected case options and selected cases so that all cases selected can have this action run on all of them. It then customises the action view so that it reflects running on multiple cases, including ensuring that the possible case options are possible for every selected case and allowing comments to be added to one section only (with a reference in the other selected section).

It is a large addition to the code, so I suspect once it is being tested on dev it might need patches added in. However, I have tried to account for issues in the code.