### PR TITLE
Allow SPI helper to generate links to external tools in a new action view

### DIFF
--- a/spihelper.css
+++ b/spihelper.css
@@ -17,3 +17,7 @@
 .spihelper-widthlimit {
     width: 10vw;
 }
+
+#spiHelper_userInfoTable th {
+    padding: 0 2px;
+}

--- a/spihelper.js
+++ b/spihelper.js
@@ -114,7 +114,7 @@ let spiHelperPageName = mw.config.get('wgPageName').replace(/_/g, ' ')
  */
 let spiHelperStartingRevID = mw.config.get('wgCurRevisionId')
 
-let spiHelperIsThisPageAnArchive = mw.config.get('wgPageName').match('Wikipedia:Sockpuppet_investigations/.*/Archive.*')
+const spiHelperIsThisPageAnArchive = mw.config.get('wgPageName').match('Wikipedia:Sockpuppet_investigations/.*/Archive.*')
 
 /** @type {string} Just the username part of the case */
 let spiHelperCaseName
@@ -253,13 +253,13 @@ const spiHelperHiddenCharNormRegex = /\u200E/g
 const spihelperAdvert = ' (using [[:w:en:User:GeneralNotability/spihelper|spihelper.js]])'
 
 /* Used by the link view */
-const spiHelper_linkViewURLFormats = {
-  'editorInteractionAnalyser': { baseurl: 'https://sigma.toolforge.org/editorinteract.py', appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'Editor Interaction Anaylser'},
-  'interactionTimeline': { baseurl: 'https://interaction-timeline.toolforge.org/', appendToQueryString: 'wiki=enwiki', userQueryStringKey: 'user', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'Interaction Timeline'},
-  'timecardSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timecard/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'Timecard comparisons'},
-  'consolidatedTimelineSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timecard/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'Consolidated Timeline (requires login)'},
-  'pagesSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timeline/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'SPI Tools Pages (requires login)'},
-  'checkUserWikiSearch': { baseurl: 'https://checkuser.wikimedia.org/w/index.php', appendToQueryString: 'ns0=1', userQueryStringKey: 'search', userQueryStringSeparator: ' OR ', userQueryStringWrapper: '"', multipleUserQueryStringKeys: false, name: 'Checkuser wiki search'},
+const spiHelperLinkViewURLFormats = {
+  editorInteractionAnalyser: { baseurl: 'https://sigma.toolforge.org/editorinteract.py', appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'Editor Interaction Anaylser' },
+  interactionTimeline: { baseurl: 'https://interaction-timeline.toolforge.org/', appendToQueryString: 'wiki=enwiki', userQueryStringKey: 'user', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'Interaction Timeline' },
+  timecardSPITools: { baseurl: 'https://spi-tools.toolforge.org/spi/timecard/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'Timecard comparisons' },
+  consolidatedTimelineSPITools: { baseurl: 'https://spi-tools.toolforge.org/spi/timecard/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'Consolidated Timeline (requires login)' },
+  pagesSPITools: { baseurl: 'https://spi-tools.toolforge.org/spi/timeline/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'SPI Tools Pages (requires login)' },
+  checkUserWikiSearch: { baseurl: 'https://checkuser.wikimedia.org/w/index.php', appendToQueryString: 'ns0=1', userQueryStringKey: 'search', userQueryStringSeparator: ' OR ', userQueryStringWrapper: '"', multipleUserQueryStringKeys: false, name: 'Checkuser wiki search' }
 }
 
 /* Actually put the portlets in place if needed */
@@ -1057,13 +1057,13 @@ async function spiHelperPerformActions () {
  
   if (spiHelperActionsSelected.Link) {
     $('#linkViewResults', document).show()
-    const spiHelper_usersForLinks = {
-      'editorInteractionAnalyser': [],
-      'interactionTimeline': [],
-      'timecardSPITools': [],
-      'consolidatedTimelineSPITools': [],
-      'pagesSPITools': [],
-      'checkUserWikiSearch': []
+    const spiHelperUsersForLinks = {
+      editorInteractionAnalyser: [],
+      interactionTimeline: [],
+      timecardSPITools: [],
+      consolidatedTimelineSPITools: [],
+      pagesSPITools: [],
+      checkUserWikiSearch: []
     }
     for (let i = 1; i <= spiHelperLinkTableUserCount; i++) {
       const username = $('#spiHelper_link_username' + i, $actionView).val().toString()
@@ -1071,22 +1071,21 @@ async function spiHelperPerformActions () {
         // Skip blank usernames
         continue
       }
-      if ($('#spiHelper_link_editorInteractionAnalyser' + i, $actionView).prop('checked')) spiHelper_usersForLinks.editorInteractionAnalyser.push(username)
-      if ($('#spiHelper_link_interactionTimeline' + i, $actionView).prop('checked')) spiHelper_usersForLinks.interactionTimeline.push(username)
-      if ($('#spiHelper_link_timecardSPITools' + i, $actionView).prop('checked')) spiHelper_usersForLinks.timecardSPITools.push(username)
-      if ($('#spiHelper_link_consolidatedTimelineSPITools' + i, $actionView).prop('checked')) spiHelper_usersForLinks.consolidatedTimelineSPITools.push(username)
-      if ($('#spiHelper_link_pagesSPITools' + i, $actionView).prop('checked')) spiHelper_usersForLinks.pagesSPITools.push(username)
-      if ($('#spiHelper_link_checkUserWikiSearch' + i, $actionView).prop('checked')) spiHelper_usersForLinks.checkUserWikiSearch.push(username)
+      if ($('#spiHelper_link_editorInteractionAnalyser' + i, $actionView).prop('checked')) spiHelperUsersForLinks.editorInteractionAnalyser.push(username)
+      if ($('#spiHelper_link_interactionTimeline' + i, $actionView).prop('checked')) spiHelperUsersForLinks.interactionTimeline.push(username)
+      if ($('#spiHelper_link_timecardSPITools' + i, $actionView).prop('checked')) spiHelperUsersForLinks.timecardSPITools.push(username)
+      if ($('#spiHelper_link_consolidatedTimelineSPITools' + i, $actionView).prop('checked')) spiHelperUsersForLinks.consolidatedTimelineSPITools.push(username)
+      if ($('#spiHelper_link_pagesSPITools' + i, $actionView).prop('checked')) spiHelperUsersForLinks.pagesSPITools.push(username)
+      if ($('#spiHelper_link_checkUserWikiSearch' + i, $actionView).prop('checked')) spiHelperUsersForLinks.checkUserWikiSearch.push(username)
     }
 
-
-    const $linkViewList = $('#linkViewResultsList')
-    for (let link in spiHelper_usersForLinks) {
-      if (spiHelper_usersForLinks[link].length === 0) continue
-      const URLentry = spiHelper_linkViewURLFormats[link]
-      let generatedURL = URLentry.baseurl + '?' + (URLentry.multipleUserQueryStringKeys ? '' : URLentry.userQueryStringKey + "=")
-      for (let i = 0; i < spiHelper_usersForLinks[link].length; i++) {
-        const username = spiHelper_usersForLinks[link][i]
+    const $linkViewList = $('#linkViewResultsList', document)
+    for (const link in spiHelperUsersForLinks) {
+      if (spiHelperUsersForLinks[link].length === 0) continue
+      const URLentry = spiHelperLinkViewURLFormats[link]
+      let generatedURL = URLentry.baseurl + '?' + (URLentry.multipleUserQueryStringKeys ? '' : URLentry.userQueryStringKey + '=')
+      for (let i = 0; i < spiHelperUsersForLinks[link].length; i++) {
+        const username = spiHelperUsersForLinks[link][i]
         generatedURL += (i === 0 ? '' : URLentry.userQueryStringSeparator)
         if (URLentry.multipleUserQueryStringKeys) {
           generatedURL += URLentry.userQueryStringKey + "=" + URLentry.userQueryStringWrapper + encodeURIComponent(username) + URLentry.userQueryStringWrapper
@@ -1094,10 +1093,10 @@ async function spiHelperPerformActions () {
           generatedURL += URLentry.userQueryStringWrapper + encodeURIComponent(username) + URLentry.userQueryStringWrapper
         }
       }
-      generatedURL += (URLentry.appendToQueryString === '' ? '': "&") + URLentry.appendToQueryString
+      generatedURL += (URLentry.appendToQueryString === '' ? '' : '&') + URLentry.appendToQueryString
       const $statusLine = $('<li>').appendTo($linkViewList)
       const $statusLineLink = $('<a>').appendTo($statusLine)
-      $statusLineLink.attr('href', generatedURL).attr('target', '_blank').attr('rel', 'noopener noreferrer').text(spiHelper_linkViewURLFormats[link].name)
+      $statusLineLink.attr('href', generatedURL).attr('target', '_blank').attr('rel', 'noopener noreferrer').text(spiHelperLinkViewURLFormats[link].name)
     }
   }
 

--- a/spihelper.js
+++ b/spihelper.js
@@ -3501,8 +3501,8 @@ function spiHelperMakeNewArchiveNotice (username, archiveNoticeParams) {
  * @return {Promise<void>}
  */
 // eslint-disable-next-line no-unused-vars
-async function spiHelperAddBlankUserLine (table_name) {
-  if (table_name === 'block') {
+async function spiHelperAddBlankUserLine (tableName) {
+  if (tableName === 'block') {
     spiHelperBlockTableUserCount++
     await spiHelperGenerateBlockTableLine('', true, spiHelperBlockTableUserCount)
   } else {

--- a/spihelper.js
+++ b/spihelper.js
@@ -161,7 +161,7 @@ const spiHelperGlobalLocks = []
 // Count of unique users in the case (anything with a checkuser, checkip, user, ip, or vandal template on the page) for the block view
 let spiHelperBlockTableUserCount = 0
 // Count of unique users in the case (anything with a checkuser, checkip, user, ip, or vandal template on the page) for the link view (seperate needed as extra rows can be added)
-let spiHelperBlockTableUserCount = 0
+let spiHelperLinkTableUserCount = 0
 
 // The current wiki's interwiki prefix
 const spiHelperInterwikiPrefix = spiHelperGetInterwikiPrefix()
@@ -428,12 +428,12 @@ const spiHelperActionViewHTML = `
       </tr>
       <tr style="border-bottom:2px solid black">
         <td style="text-align:center;">(All users)</td>
-        <td><input type="checkbox" id="spiHelper_line_editorInteractionAnalyser"/></td>
-        <td><input type="checkbox" id="spiHelper_line_interactionTimeline"/></td>
-        <td><input type="checkbox" id="spiHelper_line_timecardSPItools"/></td>
-        <td class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_line_consolidatedTimelineSPITools"/></td>
-        <td class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_line_pagesSPITools"/></td>
-        <td class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_line_checkUserWikiSearch"/></td>
+        <td><input type="checkbox" id="spiHelper_link_editorInteractionAnalyser"/></td>
+        <td><input type="checkbox" id="spiHelper_link_interactionTimeline"/></td>
+        <td><input type="checkbox" id="spiHelper_link_timecardSPItools"/></td>
+        <td class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_link_consolidatedTimelineSPITools"/></td>
+        <td class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_link_pagesSPITools"/></td>
+        <td class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_link_checkUserWikiSearch"/></td>
       </tr>
     </table>
     <span><input type="button" id="moreSerks" value="Add Row" onclick="spiHelperAddBlankUserLine();"/></span>
@@ -557,6 +557,7 @@ async function spiHelperGenerateForm () {
   const $topView = $('#spiHelper_topViewDiv', document)
   spiHelperActionsSelected.Case_act = $('#spiHelper_Case_Action', $topView).prop('checked')
   spiHelperActionsSelected.Block = $('#spiHelper_BlockTag', $topView).prop('checked')
+  spiHelperActionsSelected.Link = $('#spiHelper_userInfo', $topView).prop('checked')
   spiHelperActionsSelected.Note = $('#spiHelper_Comment', $topView).prop('checked')
   spiHelperActionsSelected.Close = $('#spiHelper_Close', $topView).prop('checked')
   spiHelperActionsSelected.Rename = $('#spiHelper_Move', $topView).prop('checked')
@@ -565,7 +566,7 @@ async function spiHelperGenerateForm () {
   const pagetext = await spiHelperGetPageText(spiHelperPageName, false, spiHelperSectionId)
   if (!(spiHelperActionsSelected.Case_act ||
     spiHelperActionsSelected.Note || spiHelperActionsSelected.Close ||
-    spiHelperActionsSelected.Archive || spiHelperActionsSelected.Block ||
+    spiHelperActionsSelected.Archive || spiHelperActionsSelected.Block || spiHelperActionsSelected.Link ||
     spiHelperActionsSelected.Rename || spiHelperActionsSelected.SpiMgmt)) {
     displayMessage('')
     return
@@ -767,105 +768,105 @@ async function spiHelperGenerateForm () {
         }
       }
     }
-  }
-  if (spiHelperActionsSelected.Block) {
-    if (spiHelperIsAdmin()) {
-      $('#spiHelper_blockTagHeader', $actionView).text('Blocking and tagging socks')
+    if (spiHelperActionsSelected.Block) {
+      if (spiHelperIsAdmin()) {
+        $('#spiHelper_blockTagHeader', $actionView).text('Blocking and tagging socks')
+      } else {
+        $('#spiHelper_blockTagHeader', $actionView).text('Tagging socks')
+      }
+      // Wire up the "select all" options
+      $('#spiHelper_block_doblock', $actionView).on('click', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'block')
+      })
+      $('#spiHelper_block_acb', $actionView).on('click', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'block')
+      })
+      $('#spiHelper_block_ab', $actionView).on('click', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'block')
+      })
+      $('#spiHelper_block_tp', $actionView).on('click', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'block')
+      })
+      $('#spiHelper_block_email', $actionView).on('click', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'block')
+      })
+      $('#spiHelper_block_lock', $actionView).on('click', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'block')
+      })
+      $('#spiHelper_block_lock', $actionView).on('click', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'block')
+      })
+      spiHelperGenerateSelect('spiHelper_block_tag', spiHelperTagOptions)
+      $('#spiHelper_block_tag', $actionView).on('change', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'block')
+      })
+      spiHelperGenerateSelect('spiHelper_block_tag_altmaster', spiHelperAltMasterTagOptions)
+      $('#spiHelper_block_tag_altmaster', $actionView).on('change', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'block')
+      })
+      $('#spiHelper_block_lock', $actionView).on('click', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'block')
+      })
+
+      for (let i = 0; i < likelyusers.length; i++) {
+        spiHelperBlockTableUserCount++
+        await spiHelperGenerateBlockTableLine(likelyusers[i], true, spiHelperBlockTableUserCount)
+      }
+      for (let i = 0; i < likelyips.length; i++) {
+        spiHelperBlockTableUserCount++
+        await spiHelperGenerateBlockTableLine(likelyips[i], true, spiHelperBlockTableUserCount)
+      }
+      for (let i = 0; i < possibleusers.length; i++) {
+        spiHelperBlockTableUserCount++
+        await spiHelperGenerateBlockTableLine(possibleusers[i], false, spiHelperBlockTableUserCount)
+      }
+      for (let i = 0; i < possibleips.length; i++) {
+        spiHelperBlockTableUserCount++
+        await spiHelperGenerateBlockTableLine(possibleips[i], false, spiHelperBlockTableUserCount)
+      }
     } else {
-      $('#spiHelper_blockTagHeader', $actionView).text('Tagging socks')
+      $('#spiHelper_blockTagView', $actionView).hide()
     }
-    // Wire up the "select all" options
-    $('#spiHelper_block_doblock', $actionView).on('click', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'block')
-    })
-    $('#spiHelper_block_acb', $actionView).on('click', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'block')
-    })
-    $('#spiHelper_block_ab', $actionView).on('click', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'block')
-    })
-    $('#spiHelper_block_tp', $actionView).on('click', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'block')
-    })
-    $('#spiHelper_block_email', $actionView).on('click', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'block')
-    })
-    $('#spiHelper_block_lock', $actionView).on('click', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'block')
-    })
-    $('#spiHelper_block_lock', $actionView).on('click', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'block')
-    })
-    spiHelperGenerateSelect('spiHelper_block_tag', spiHelperTagOptions)
-    $('#spiHelper_block_tag', $actionView).on('change', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'block')
-    })
-    spiHelperGenerateSelect('spiHelper_block_tag_altmaster', spiHelperAltMasterTagOptions)
-    $('#spiHelper_block_tag_altmaster', $actionView).on('change', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'block')
-    })
-    $('#spiHelper_block_lock', $actionView).on('click', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'block')
-    })
+    if (spiHelperActionsSelected.Link) {
+      // Wire up the "select all" options
+      $('#spiHelper_editorInteractionAnalyser', $actionView).on('click', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'link')
+      })
+      $('#spiHelper_interactionTimeline', $actionView).on('click', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'link')
+      })
+      $('#spiHelper_interactionTimeline', $actionView).on('click', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'link')
+      })
+      $('#spiHelper_consolidatedTimelineSPITools', $actionView).on('click', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'link')
+      })
+      $('#spiHelper_pagesSPITools', $actionView).on('click', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'link')
+      })
+      $('#spiHelper_checkUserWikiSearch', $actionView).on('click', function (e) {
+        spiHelperSetAllTableColumnOpts($(e.target), 'link')
+      })
 
-    for (let i = 0; i < likelyusers.length; i++) {
-      spiHelperBlockTableUserCount++
-      await spiHelperGenerateBlockTableLine(likelyusers[i], true, spiHelperBlockTableUserCount)
+      for (let i = 0; i < likelyusers.length; i++) {
+        spiHelperLinkTableUserCount++
+        await spiHelperGenerateLinksTableLine(likelyusers[i], spiHelperLinkTableUserCount)
+      }
+      for (let i = 0; i < likelyips.length; i++) {
+        spiHelperLinkTableUserCount++
+        await spiHelperGenerateLinksTableLine(likelyips[i], spiHelperLinkTableUserCount)
+      }
+      for (let i = 0; i < possibleusers.length; i++) {
+        spiHelperLinkTableUserCount++
+        await spiHelperGenerateLinksTableLine(possibleusers[i], spiHelperLinkTableUserCount)
+      }
+      for (let i = 0; i < possibleips.length; i++) {
+        spiHelperLinkTableUserCount++
+        await spiHelperGenerateLinksTableLine(possibleips[i], spiHelperLinkTableUserCount)
+      }
+    } else {
+      $('#spiHelper_sockLinksView', $actionView).hide()
     }
-    for (let i = 0; i < likelyips.length; i++) {
-      spiHelperBlockTableUserCount++
-      await spiHelperGenerateBlockTableLine(likelyips[i], true, spiHelperBlockTableUserCount)
-    }
-    for (let i = 0; i < possibleusers.length; i++) {
-      spiHelperBlockTableUserCount++
-      await spiHelperGenerateBlockTableLine(possibleusers[i], false, spiHelperBlockTableUserCount)
-    }
-    for (let i = 0; i < possibleips.length; i++) {
-      spiHelperBlockTableUserCount++
-      await spiHelperGenerateBlockTableLine(possibleips[i], false, spiHelperBlockTableUserCount)
-    }
-  } else {
-    $('#spiHelper_blockTagView', $actionView).hide()
-  }
-  if (spiHelperActionsSelected.Links) {
-    // Wire up the "select all" options
-    $('#spiHelper_editorInteractionAnalyser', $actionView).on('click', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'link')
-    })
-    $('#spiHelper_interactionTimeline', $actionView).on('click', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'link')
-    })
-    $('#spiHelper_interactionTimeline', $actionView).on('click', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'link')
-    })
-    $('#spiHelper_consolidatedTimelineSPITools', $actionView).on('click', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'link')
-    })
-    $('#spiHelper_pagesSPITools', $actionView).on('click', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'link')
-    })
-    $('#spiHelper_checkUserWikiSearch', $actionView).on('click', function (e) {
-      spiHelperSetAllTableColumnOpts($(e.target), 'link')
-    })
-
-    for (let i = 0; i < likelyusers.length; i++) {
-      spiHelperLinkTableUserCount++
-      await spiHelperGenerateLinksTableLine(likelyusers[i], spiHelperLinkTableUserCount)
-    }
-    for (let i = 0; i < likelyips.length; i++) {
-      spiHelperLinkTableUserCount++
-      await spiHelperGenerateLinksTableLine(likelyips[i], spiHelperLinkTableUserCount)
-    }
-    for (let i = 0; i < possibleusers.length; i++) {
-      spiHelperLinkTableUserCount++
-      await spiHelperGenerateLinksTableLine(possibleusers[i], spiHelperLinkTableUserCount)
-    }
-    for (let i = 0; i < possibleips.length; i++) {
-      spiHelperLinkTableUserCount++
-      await spiHelperGenerateLinksTableLine(possibleips[i], spiHelperLinkTableUserCount)
-    }
-  } else {
-    $('#spiHelper_sockLinksView', $actionView).hide()
   }
   // Wire up the submit button
   $('#spiHelper_performActions', $actionView).one('click', () => {
@@ -1054,7 +1055,7 @@ async function spiHelperPerformActions () {
   }
   logMessage += ' ~~~~~'
  
-  if (spiHelperActionsSelected.Line) {
+  if (spiHelperActionsSelected.Link) {
     const spiHelper_usersForLinks = {
       'editorInteractionAnalyser': [],
       'interactionTimeline': [],
@@ -1064,17 +1065,17 @@ async function spiHelperPerformActions () {
       'checkUserWikiSearch': []
     }
     for (let i = 1; i <= spiHelperLinkTableUserCount; i++) {
-      const username = $('#spiHelper_line_username' + i, $actionView).val().toString()
+      const username = $('#spiHelper_link_username' + i, $actionView).val().toString()
       if (!username) {
         // Skip blank usernames
         continue
       }
-      if ($('#spiHelper_line_editorInteractionAnalyser' + i, $actionView).prop('checked')) spiHelper_usersForLinks.editorInteractionAnalyser.push(username)
-      if ($('#spiHelper_line_interactionTimeline' + i, $actionView).prop('checked')) spiHelper_usersForLinks.interactionTimeline.push(username)
-      if ($('#spiHelper_line_timecardSPITools' + i, $actionView).prop('checked')) spiHelper_usersForLinks.timecardSPITools.push(username)
-      if ($('#spiHelper_line_consolidatedTimelineSPITools' + i, $actionView).prop('checked')) spiHelper_usersForLinks.consolidatedTimelineSPITools.push(username)
-      if ($('#spiHelper_line_pagesSPITools' + i, $actionView).prop('checked')) spiHelper_usersForLinks.pagesSPITools.push(username)
-      if ($('#spiHelper_line_checkUserWikiSearch' + i, $actionView).prop('checked')) spiHelper_usersForLinks.checkUserWikiSearch.push(username)
+      if ($('#spiHelper_link_editorInteractionAnalyser' + i, $actionView).prop('checked')) spiHelper_usersForLinks.editorInteractionAnalyser.push(username)
+      if ($('#spiHelper_link_interactionTimeline' + i, $actionView).prop('checked')) spiHelper_usersForLinks.interactionTimeline.push(username)
+      if ($('#spiHelper_link_timecardSPITools' + i, $actionView).prop('checked')) spiHelper_usersForLinks.timecardSPITools.push(username)
+      if ($('#spiHelper_link_consolidatedTimelineSPITools' + i, $actionView).prop('checked')) spiHelper_usersForLinks.consolidatedTimelineSPITools.push(username)
+      if ($('#spiHelper_link_pagesSPITools' + i, $actionView).prop('checked')) spiHelper_usersForLinks.pagesSPITools.push(username)
+      if ($('#spiHelper_link_checkUserWikiSearch' + i, $actionView).prop('checked')) spiHelper_usersForLinks.checkUserWikiSearch.push(username)
     }
     
     const $linkViewList = $('<ul>').appendTo($('#spiHelper_status', document))
@@ -1083,6 +1084,7 @@ async function spiHelperPerformActions () {
       const URLentry = spiHelper_linkViewURLFormats[link]
       let generatedURL = URLentry.baseurl + '?' + (URLentry.multipleUserQueryStringKeys ? '' : URLentry.userQueryStringKey + "=")
       for (let i = 0; i < spiHelper_usersForLinks[link].length; i++) {
+        const username = spiHelper_usersForLinks[link][i]
         generatedURL += (i === 0 ? '' : URLentry.userQueryStringSeparator)
         if (URLentry.multipleUserQueryStringKeys) {
           generatedURL += URLentry.userQueryStringKey + "=" + username
@@ -2966,30 +2968,30 @@ async function spiHelperGenerateBlockTableLine (name, defaultblock, id) {
 async function spiHelperGenerateLinksTableLine (username, id) {
   'use strict'
 
-  const $table = $('#spiHelper_blockTable', document)
+  const $table = $('#spiHelper_userInfoTable', document)
 
   const $row = $('<tr>')
   // Username
   $('<td>').append($('<input>').attr('type', 'text').attr('id', 'spiHelper_link_username' + id)
-    .val(name).addClass('.spihelper-widthlimit')).appendTo($row)
+    .val(username).addClass('.spihelper-widthlimit')).appendTo($row)
   // Editor interaction analyser
   $('<td>').append($('<input>').attr('type', 'checkbox')
-    .attr('id', 'spiHelper_link_editorInteractionAnalyser' + id).appendTo($row)
+    .attr('id', 'spiHelper_link_editorInteractionAnalyser' + id)).appendTo($row)
   // Interaction timeline
   $('<td>').append($('<input>').attr('type', 'checkbox')
-    .attr('id', 'spiHelper_link_interactionTimeline' + id).appendTo($row)
+    .attr('id', 'spiHelper_link_interactionTimeline' + id)).appendTo($row)
   // SPI tools timecard tool
   $('<td>').append($('<input>').attr('type', 'checkbox')
-    .attr('id', 'spiHelper_link_timecardSPItools' + id).appendTo($row)
+    .attr('id', 'spiHelper_link_timecardSPItools' + id)).appendTo($row)
   // SPI tools consilidated timeline (admin only based on OAUTH requirements)
   $('<td>').addClass('spiHelper_adminClass').append($('<input>').attr('type', 'checkbox')
-    .attr('id', 'spiHelper_link_consolidatedTimelineSPITools' + id).appendTo($row)
+    .attr('id', 'spiHelper_link_consolidatedTimelineSPITools' + id)).appendTo($row)
   // SPI tools pages tool (admin only based on OAUTH requirements)
   $('<td>').addClass('spiHelper_adminClass').append($('<input>').attr('type', 'checkbox')
-    .attr('id', 'spiHelper_link_pagesSPITools' + id).prop('checked', ntp)).appendTo($row)
+    .attr('id', 'spiHelper_link_pagesSPITools' + id)).appendTo($row)
   // Checkuser wiki search (CU only)
   $('<td>').addClass('spiHelper_cuClass').append($('<input>').attr('type', 'checkbox')
-    .attr('id', 'spiHelper_link_checkUserWikiSearch' + id).appendTo($row)
+    .attr('id', 'spiHelper_link_checkUserWikiSearch' + id)).appendTo($row)
   $table.append($row)
 }
 

--- a/spihelper.js
+++ b/spihelper.js
@@ -428,12 +428,12 @@ const spiHelperActionViewHTML = `
       </tr>
       <tr style="border-bottom:2px solid black">
         <td style="text-align:center;">(All users)</td>
-        <td><input type="checkbox" id="spiHelper_link_editorInteractionAnalyser"/></td>
-        <td><input type="checkbox" id="spiHelper_link_interactionTimeline"/></td>
-        <td><input type="checkbox" id="spiHelper_link_timecardSPITools"/></td>
-        <td class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_link_consolidatedTimelineSPITools"/></td>
-        <td class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_link_pagesSPITools"/></td>
-        <td class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_link_checkUserWikiSearch"/></td>
+        <td style="text-align:center;"><input type="checkbox" id="spiHelper_link_editorInteractionAnalyser"/></td>
+        <td style="text-align:center;"><input type="checkbox" id="spiHelper_link_interactionTimeline"/></td>
+        <td style="text-align:center;"><input type="checkbox" id="spiHelper_link_timecardSPITools"/></td>
+        <td style="text-align:center;" class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_link_consolidatedTimelineSPITools"/></td>
+        <td style="text-align:center;" class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_link_pagesSPITools"/></td>
+        <td style="text-align:center;" class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_link_checkUserWikiSearch"/></td>
       </tr>
     </table>
     <span><input type="button" id="moreSerks" value="Add Row" onclick="spiHelperAddBlankUserLine();"/></span>
@@ -2978,22 +2978,22 @@ async function spiHelperGenerateLinksTableLine (username, id) {
     .val(username).addClass('.spihelper-widthlimit')).appendTo($row)
   // Editor interaction analyser
   $('<td>').append($('<input>').attr('type', 'checkbox')
-    .attr('id', 'spiHelper_link_editorInteractionAnalyser' + id)).appendTo($row)
+    .attr('id', 'spiHelper_link_editorInteractionAnalyser' + id)).attr('style', 'text-align:center;').appendTo($row)
   // Interaction timeline
   $('<td>').append($('<input>').attr('type', 'checkbox')
-    .attr('id', 'spiHelper_link_interactionTimeline' + id)).appendTo($row)
+    .attr('id', 'spiHelper_link_interactionTimeline' + id)).attr('style', 'text-align:center;').appendTo($row)
   // SPI tools timecard tool
   $('<td>').append($('<input>').attr('type', 'checkbox')
-    .attr('id', 'spiHelper_link_timecardSPITools' + id)).appendTo($row)
+    .attr('id', 'spiHelper_link_timecardSPITools' + id)).attr('style', 'text-align:center;').appendTo($row)
   // SPI tools consilidated timeline (admin only based on OAUTH requirements)
   $('<td>').addClass('spiHelper_adminClass').append($('<input>').attr('type', 'checkbox')
-    .attr('id', 'spiHelper_link_consolidatedTimelineSPITools' + id)).appendTo($row)
+    .attr('id', 'spiHelper_link_consolidatedTimelineSPITools' + id)).attr('style', 'text-align:center;').appendTo($row)
   // SPI tools pages tool (admin only based on OAUTH requirements)
   $('<td>').addClass('spiHelper_adminClass').append($('<input>').attr('type', 'checkbox')
-    .attr('id', 'spiHelper_link_pagesSPITools' + id)).appendTo($row)
+    .attr('id', 'spiHelper_link_pagesSPITools' + id)).attr('style', 'text-align:center;').appendTo($row)
   // Checkuser wiki search (CU only)
   $('<td>').addClass('spiHelper_cuClass').append($('<input>').attr('type', 'checkbox')
-    .attr('id', 'spiHelper_link_checkUserWikiSearch' + id)).appendTo($row)
+    .attr('id', 'spiHelper_link_checkUserWikiSearch' + id)).attr('style', 'text-align:center;').appendTo($row)
   $table.append($row)
 }
 

--- a/spihelper.js
+++ b/spihelper.js
@@ -436,7 +436,7 @@ const spiHelperActionViewHTML = `
         <td style="text-align:center;" class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_link_checkUserWikiSearch"/></td>
       </tr>
     </table>
-    <span><input type="button" id="moreSerks" value="Add Row" onclick="spiHelperAddBlankUserLine();"/></span>
+    <span><input type="button" id="moreSerks" value="Add Row" onclick="spiHelperAddBlankUserLine("block");"/></span>
   </div>
   <div id="spiHelper_blockTagView">
     <h4 id="spiHelper_blockTagHeader">Blocking and tagging socks</h4>
@@ -507,7 +507,7 @@ const spiHelperActionViewHTML = `
         <td><input type="checkbox" name="spiHelper_block_lock_all" id="spiHelper_block_lock"/></td>
       </tr>
     </table>
-    <span><input type="button" id="moreSerks" value="Add Row" onclick="spiHelperAddBlankUserLine();"/></span>
+    <span><input type="button" id="moreSerks" value="Add Row" onclick="spiHelperAddBlankUserLine("block");"/></span>
   </div>
   <div id="spiHelper_closeView">
     <h4>Marking case as closed</h4>
@@ -3501,8 +3501,8 @@ function spiHelperMakeNewArchiveNotice (username, archiveNoticeParams) {
  * @return {Promise<void>}
  */
 // eslint-disable-next-line no-unused-vars
-async function spiHelperAddBlankUserLine () {
-  if (spiHelperActionsSelected.Block) {
+async function spiHelperAddBlankUserLine (table_name) {
+  if (table_name === 'block') {
     spiHelperBlockTableUserCount++
     await spiHelperGenerateBlockTableLine('', true, spiHelperBlockTableUserCount)
   } else {

--- a/spihelper.js
+++ b/spihelper.js
@@ -254,12 +254,12 @@ const spihelperAdvert = ' (using [[:w:en:User:GeneralNotability/spihelper|spihel
 
 /* Used by the link view */
 const spiHelper_linkViewURLFormats = {
-  'editorInteractionAnalyser': { baseurl: 'https://sigma.toolforge.org/editorinteract.py', appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', multipleUserQueryStringKeys: true, name: 'Editor Interaction Anaylser'},
-  'interactionTimeline': { baseurl: 'https://interaction-timeline.toolforge.org/', appendToQueryString: 'wiki=enwiki', userQueryStringKey: 'user', userQueryStringSeparator: '&', multipleUserQueryStringKeys: true, name: 'Interaction Timeline'},
-  'timecardSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timecard/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', multipleUserQueryStringKeys: true, name: 'Timecard comparisons'},
-  'consolidatedTimelineSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timecard/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', multipleUserQueryStringKeys: true, name: 'Consolidated Timeline (requires login)'},
-  'pagesSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timeline/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', multipleUserQueryStringKeys: true, name: 'SPI Tools Pages (requires login)'},
-  'checkUserWikiSearch': { baseurl: 'https://checkuser.wikimedia.org/w/index.php', appendToQueryString: 'ns0=1', userQueryStringKey: 'search', userQueryStringSeparator: ' OR ', multipleUserQueryStringKeys: false, name: 'Checkuser wiki search'},
+  'editorInteractionAnalyser': { baseurl: 'https://sigma.toolforge.org/editorinteract.py', appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'Editor Interaction Anaylser'},
+  'interactionTimeline': { baseurl: 'https://interaction-timeline.toolforge.org/', appendToQueryString: 'wiki=enwiki', userQueryStringKey: 'user', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'Interaction Timeline'},
+  'timecardSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timecard/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'Timecard comparisons'},
+  'consolidatedTimelineSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timecard/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'Consolidated Timeline (requires login)'},
+  'pagesSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timeline/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', userQueryStringWrapper: '', multipleUserQueryStringKeys: true, name: 'SPI Tools Pages (requires login)'},
+  'checkUserWikiSearch': { baseurl: 'https://checkuser.wikimedia.org/w/index.php', appendToQueryString: 'ns0=1', userQueryStringKey: 'search', userQueryStringSeparator: ' OR ', userQueryStringWrapper: '"', multipleUserQueryStringKeys: false, name: 'Checkuser wiki search'},
 }
 
 /* Actually put the portlets in place if needed */
@@ -430,7 +430,7 @@ const spiHelperActionViewHTML = `
         <td style="text-align:center;">(All users)</td>
         <td><input type="checkbox" id="spiHelper_link_editorInteractionAnalyser"/></td>
         <td><input type="checkbox" id="spiHelper_link_interactionTimeline"/></td>
-        <td><input type="checkbox" id="spiHelper_link_timecardSPItools"/></td>
+        <td><input type="checkbox" id="spiHelper_link_timecardSPITools"/></td>
         <td class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_link_consolidatedTimelineSPITools"/></td>
         <td class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_link_pagesSPITools"/></td>
         <td class="spiHelper_adminClass"><input type="checkbox" id="spiHelper_link_checkUserWikiSearch"/></td>
@@ -829,22 +829,22 @@ async function spiHelperGenerateForm () {
     }
     if (spiHelperActionsSelected.Link) {
       // Wire up the "select all" options
-      $('#spiHelper_editorInteractionAnalyser', $actionView).on('click', function (e) {
+      $('#spiHelper_link_editorInteractionAnalyser', $actionView).on('click', function (e) {
         spiHelperSetAllTableColumnOpts($(e.target), 'link')
       })
-      $('#spiHelper_interactionTimeline', $actionView).on('click', function (e) {
+      $('#spiHelper_link_interactionTimeline', $actionView).on('click', function (e) {
         spiHelperSetAllTableColumnOpts($(e.target), 'link')
       })
-      $('#spiHelper_interactionTimeline', $actionView).on('click', function (e) {
+      $('#spiHelper_link_interactionTimeline', $actionView).on('click', function (e) {
         spiHelperSetAllTableColumnOpts($(e.target), 'link')
       })
-      $('#spiHelper_consolidatedTimelineSPITools', $actionView).on('click', function (e) {
+      $('#spiHelper_link_consolidatedTimelineSPITools', $actionView).on('click', function (e) {
         spiHelperSetAllTableColumnOpts($(e.target), 'link')
       })
-      $('#spiHelper_pagesSPITools', $actionView).on('click', function (e) {
+      $('#spiHelper_link_pagesSPITools', $actionView).on('click', function (e) {
         spiHelperSetAllTableColumnOpts($(e.target), 'link')
       })
-      $('#spiHelper_checkUserWikiSearch', $actionView).on('click', function (e) {
+      $('#spiHelper_link_checkUserWikiSearch', $actionView).on('click', function (e) {
         spiHelperSetAllTableColumnOpts($(e.target), 'link')
       })
 
@@ -1078,23 +1078,26 @@ async function spiHelperPerformActions () {
       if ($('#spiHelper_link_checkUserWikiSearch' + i, $actionView).prop('checked')) spiHelper_usersForLinks.checkUserWikiSearch.push(username)
     }
     
+    const $headerLinkViewList = $('<p>').appendTo($('#spiHelper_status', document))
+    $headerLinkViewList.text('Generated links')
     const $linkViewList = $('<ul>').appendTo($('#spiHelper_status', document))
     for (let link in spiHelper_usersForLinks) {
-      if (spiHelper_usersForLinks[link].length === 0) return
+      if (spiHelper_usersForLinks[link].length === 0) continue
       const URLentry = spiHelper_linkViewURLFormats[link]
       let generatedURL = URLentry.baseurl + '?' + (URLentry.multipleUserQueryStringKeys ? '' : URLentry.userQueryStringKey + "=")
       for (let i = 0; i < spiHelper_usersForLinks[link].length; i++) {
         const username = spiHelper_usersForLinks[link][i]
         generatedURL += (i === 0 ? '' : URLentry.userQueryStringSeparator)
         if (URLentry.multipleUserQueryStringKeys) {
-          generatedURL += URLentry.userQueryStringKey + "=" + username
+          generatedURL += URLentry.userQueryStringKey + "=" + URLentry.userQueryStringWrapper + username + URLentry.userQueryStringWrapper
         } else {
-          generatedURL += username
+          generatedURL += URLentry.userQueryStringWrapper + username + URLentry.userQueryStringWrapper
         }
       }
-      generatedURL += URLentry.appendToQueryString
+      generatedURL += (URLentry.appendToQueryString === '' ? '': "&") + URLentry.appendToQueryString
       const $statusLine = $('<li>').appendTo($linkViewList)
-      $statusLine.append($('a').attr('href', generatedURL).attr('target', '_blank').attr('rel', 'noopener noreferrer').text(spiHelper_linkViewURLFormats[link].name))
+      const $statusLineLink = $('<a>').appendTo($statusLine)
+      $statusLineLink.attr('href', generatedURL).attr('target', '_blank').attr('rel', 'noopener noreferrer').text(spiHelper_linkViewURLFormats[link].name)
     }
   }
 
@@ -2982,7 +2985,7 @@ async function spiHelperGenerateLinksTableLine (username, id) {
     .attr('id', 'spiHelper_link_interactionTimeline' + id)).appendTo($row)
   // SPI tools timecard tool
   $('<td>').append($('<input>').attr('type', 'checkbox')
-    .attr('id', 'spiHelper_link_timecardSPItools' + id)).appendTo($row)
+    .attr('id', 'spiHelper_link_timecardSPITools' + id)).appendTo($row)
   // SPI tools consilidated timeline (admin only based on OAUTH requirements)
   $('<td>').addClass('spiHelper_adminClass').append($('<input>').attr('type', 'checkbox')
     .attr('id', 'spiHelper_link_consolidatedTimelineSPITools' + id)).appendTo($row)
@@ -3156,7 +3159,7 @@ function spiHelperGenerateSelect (id, options) {
  */
 function spiHelperSetAllTableColumnOpts (source, forTable) {
   'use strict'
-  for (let i = 1; i <= (forTable === 'links' ? spiHelperLinkTableUserCount : spiHelperBlockTableUserCount); i++) {
+  for (let i = 1; i <= (forTable === 'link' ? spiHelperLinkTableUserCount : spiHelperBlockTableUserCount); i++) {
     const $target = $('#' + source.attr('id') + i)
     if (source.attr('type') === 'checkbox') {
       // Don't try to set disabled checkboxes

--- a/spihelper.js
+++ b/spihelper.js
@@ -254,12 +254,12 @@ const spihelperAdvert = ' (using [[:w:en:User:GeneralNotability/spihelper|spihel
 
 /* Used by the link view */
 const spiHelper_linkViewURLFormats = {
-  'editorInteractionAnalyser': { baseurl: 'https://sigma.toolforge.org/editorinteract.py', userQueryStringKey: 'users', name: 'Editor Interaction Anaylser'},
-  'interactionTimeline': { baseurl: 'https://interaction-timeline.toolforge.org/', appendToQueryString: 'wiki=enwiki', userQueryStringKey: 'user', name: 'Interaction Timeline'},
-  'timecardSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timecard/' + spiHelperCaseName, userQueryStringKey: 'users', name: 'Timecard comparisons'},
-  'consolidatedTimelineSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timecard/' + spiHelperCaseName, userQueryStringKey: 'users', name: 'Consolidated Timeline (requires login)'},
-  'pagesSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timeline/' + spiHelperCaseName, userQueryStringKey: 'users', name: 'SPI Tools Pages (requires login)'},
-  'checkUserWikiSearch': { baseurl: 'https://checkuser.wikimedia.org/w/index.php', appendToQueryString: 'ns0=1', queryStringKey: 'search', userQueryStringSeparator: ' OR ', name: 'Checkuser wiki search'},
+  'editorInteractionAnalyser': { baseurl: 'https://sigma.toolforge.org/editorinteract.py', appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', multipleUserQueryStringKeys: true, name: 'Editor Interaction Anaylser'},
+  'interactionTimeline': { baseurl: 'https://interaction-timeline.toolforge.org/', appendToQueryString: 'wiki=enwiki', userQueryStringKey: 'user', userQueryStringSeparator: '&', multipleUserQueryStringKeys: true, name: 'Interaction Timeline'},
+  'timecardSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timecard/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', multipleUserQueryStringKeys: true, name: 'Timecard comparisons'},
+  'consolidatedTimelineSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timecard/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', multipleUserQueryStringKeys: true, name: 'Consolidated Timeline (requires login)'},
+  'pagesSPITools': { baseurl: 'https://spi-tools.toolforge.org/spi/timeline/' + spiHelperCaseName, appendToQueryString: '', userQueryStringKey: 'users', userQueryStringSeparator: '&', multipleUserQueryStringKeys: true, name: 'SPI Tools Pages (requires login)'},
+  'checkUserWikiSearch': { baseurl: 'https://checkuser.wikimedia.org/w/index.php', appendToQueryString: 'ns0=1', userQueryStringKey: 'search', userQueryStringSeparator: ' OR ', multipleUserQueryStringKeys: false, name: 'Checkuser wiki search'},
 }
 
 /* Actually put the portlets in place if needed */
@@ -1077,13 +1077,22 @@ async function spiHelperPerformActions () {
       if ($('#spiHelper_line_checkUserWikiSearch' + i, $actionView).prop('checked')) spiHelper_usersForLinks.checkUserWikiSearch.push(username)
     }
     
+    const $linkViewList = $('<ul>').appendTo($('#spiHelper_status', document))
     for (let link in spiHelper_usersForLinks) {
       if (spiHelper_usersForLinks[link].length === 0) return
-      for (let username in spiHelper_usersForLinks[link]) {
-        
+      const URLentry = spiHelper_linkViewURLFormats[link]
+      let generatedURL = URLentry.baseurl + '?' + (URLentry.multipleUserQueryStringKeys ? '' : URLentry.userQueryStringKey + "=")
+      for (let i = 0; i < spiHelper_usersForLinks[link].length; i++) {
+        generatedURL += (i === 0 ? '' : URLentry.userQueryStringSeparator)
+        if (URLentry.multipleUserQueryStringKeys) {
+          generatedURL += URLentry.userQueryStringKey + "=" + username
+        } else {
+          generatedURL += username
+        }
       }
-      const $statusLine = $('<li>').appendTo($('#spiHelper_status', document))
-      $statusLine.html('<b>Block failed on ' + blockEntry.username + ', not adding talk page notice</b>')
+      generatedURL += URLentry.appendToQueryString
+      const $statusLine = $('<li>').appendTo($linkViewList)
+      $statusLine.append($('a').attr('href', generatedURL).attr('target', '_blank').attr('rel', 'noopener noreferrer').text(spiHelper_linkViewURLFormats[link].name))
     }
   }
 

--- a/spihelper.js
+++ b/spihelper.js
@@ -835,7 +835,7 @@ async function spiHelperGenerateForm () {
       $('#spiHelper_link_interactionTimeline', $actionView).on('click', function (e) {
         spiHelperSetAllTableColumnOpts($(e.target), 'link')
       })
-      $('#spiHelper_link_interactionTimeline', $actionView).on('click', function (e) {
+      $('#spiHelper_link_timecardSPITools', $actionView).on('click', function (e) {
         spiHelperSetAllTableColumnOpts($(e.target), 'link')
       })
       $('#spiHelper_link_consolidatedTimelineSPITools', $actionView).on('click', function (e) {
@@ -1041,7 +1041,7 @@ async function spiHelperPerformActions () {
     spiHelperActionsSelected.Archive = $('#spiHelper_ArchiveCase', $actionView).prop('checked')
   }
 
-  displayMessage('<ul id="spiHelper_status" />')
+  displayMessage('<div id="linkViewResults" hidden><h4>Generated links</h4><ul id="linkViewResultsList"></ul></div><h4>Running actions</h4><ul id="spiHelper_status" />')
 
   const $statusAnchor = $('#spiHelper_status', document)
 
@@ -1056,6 +1056,7 @@ async function spiHelperPerformActions () {
   logMessage += ' ~~~~~'
  
   if (spiHelperActionsSelected.Link) {
+    $('#linkViewResults', document).show()
     const spiHelper_usersForLinks = {
       'editorInteractionAnalyser': [],
       'interactionTimeline': [],
@@ -1077,10 +1078,9 @@ async function spiHelperPerformActions () {
       if ($('#spiHelper_link_pagesSPITools' + i, $actionView).prop('checked')) spiHelper_usersForLinks.pagesSPITools.push(username)
       if ($('#spiHelper_link_checkUserWikiSearch' + i, $actionView).prop('checked')) spiHelper_usersForLinks.checkUserWikiSearch.push(username)
     }
-    
-    const $headerLinkViewList = $('<p>').appendTo($('#spiHelper_status', document))
-    $headerLinkViewList.text('Generated links')
-    const $linkViewList = $('<ul>').appendTo($('#spiHelper_status', document))
+
+
+    const $linkViewList = $('#linkViewResultsList')
     for (let link in spiHelper_usersForLinks) {
       if (spiHelper_usersForLinks[link].length === 0) continue
       const URLentry = spiHelper_linkViewURLFormats[link]
@@ -1089,9 +1089,9 @@ async function spiHelperPerformActions () {
         const username = spiHelper_usersForLinks[link][i]
         generatedURL += (i === 0 ? '' : URLentry.userQueryStringSeparator)
         if (URLentry.multipleUserQueryStringKeys) {
-          generatedURL += URLentry.userQueryStringKey + "=" + URLentry.userQueryStringWrapper + username + URLentry.userQueryStringWrapper
+          generatedURL += URLentry.userQueryStringKey + "=" + URLentry.userQueryStringWrapper + encodeURIComponent(username) + URLentry.userQueryStringWrapper
         } else {
-          generatedURL += URLentry.userQueryStringWrapper + username + URLentry.userQueryStringWrapper
+          generatedURL += URLentry.userQueryStringWrapper + encodeURIComponent(username) + URLentry.userQueryStringWrapper
         }
       }
       generatedURL += (URLentry.appendToQueryString === '' ? '': "&") + URLentry.appendToQueryString

--- a/spihelper.js
+++ b/spihelper.js
@@ -1054,7 +1054,7 @@ async function spiHelperPerformActions () {
     logMessage += ' (full case)'
   }
   logMessage += ' ~~~~~'
- 
+
   if (spiHelperActionsSelected.Link) {
     $('#linkViewResults', document).show()
     const spiHelperUsersForLinks = {
@@ -1088,7 +1088,7 @@ async function spiHelperPerformActions () {
         const username = spiHelperUsersForLinks[link][i]
         generatedURL += (i === 0 ? '' : URLentry.userQueryStringSeparator)
         if (URLentry.multipleUserQueryStringKeys) {
-          generatedURL += URLentry.userQueryStringKey + "=" + URLentry.userQueryStringWrapper + encodeURIComponent(username) + URLentry.userQueryStringWrapper
+          generatedURL += URLentry.userQueryStringKey + '=' + URLentry.userQueryStringWrapper + encodeURIComponent(username) + URLentry.userQueryStringWrapper
         } else {
           generatedURL += URLentry.userQueryStringWrapper + encodeURIComponent(username) + URLentry.userQueryStringWrapper
         }


### PR DESCRIPTION
Allow SPI helper to generate links to external tools in a new action view, such as the Editor Interaction Analyser, which show useful information for selected users. Fixes #61 