### PR TITLE
Change case status and Close should be mutually exclusive

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -3162,6 +3162,12 @@ async function spiHelperSetCheckboxesBySection () {
       }
     } else {
       $archiveBox.prop('disabled', true)
+      $('#spiHelper_Case_Action', $topView).on('click', function () {
+        $('#spiHelper_Close', $topView).prop('disabled', $('#spiHelper_Case_Action', $topView).prop('checked'))
+      })
+      $('#spiHelper_Close', $topView).on('click', function () {
+        $('#spiHelper_Case_Action', $topView).prop('disabled', $('#spiHelper_Close', $topView).prop('checked'))
+      })
     }
 
     // Change the label on the rename button


### PR DESCRIPTION
Change case status and Close should be mutually exclusive because they both modify the SPI case status template. Regardless of the status selected currently in the Change case status selector will update the new case status to close as shown in https://github.com/GeneralNotability/spihelper/blob/ad97dbea6ca4102427ff227a93f1f0dd24bb8559/spihelper.js#L1623

As such if one is checked then disable the other, as close will always prevail regardless of what is checked (and this might cause confusion).