### PR TITLE
Add {{Action and close}} template

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -229,6 +229,7 @@ const spiHelperAdminTemplates = [
   { label: 'Blocked, no tags', selected: false, value: '{{bwt}}' },
   { label: 'Blocked, awaiting tags', selected: false, value: '{{sblock}}' },
   { label: 'Blocked, tagged, closed', selected: false, value: '{{btc}}' },
+  { label: 'Requested actions completed, closing', selected: false, value: '{{Action and close}}' },
   { label: 'Diffs needed', selected: false, value: '{{DiffsNeeded|moreinfo}}' },
   { label: 'Locks requested', selected: false, value: '{{GlobalLocksRequested}}' }
 ]


### PR DESCRIPTION
Adds the "Requested actions completed, closing" [template](https://en.wikipedia.org/wiki/Template:Action_and_close):

![image](https://user-images.githubusercontent.com/375162/153394405-924baf3c-dcc3-4acc-8b84-aff1a06bbe73.png)

to the "Admin/clerk templates" dropdown