### PR TITLE
Push socklist detection through to main by cherry-picking commits

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -604,7 +604,7 @@ async function spiHelperGenerateForm () {
         }
       }
     }
-    const unnamedParameterRegex = /\s*\d*\s*/gi
+    const unnamedParameterRegex = /\s*\d+\s*/gi
     const socklistResults = pagetext.match(/{{\s*sock\s?list\s*([^}]*)}}/gi)
     if (socklistResults) {
       for (let i = 0; i < socklistResults.length; i++) {

--- a/spihelper.js
+++ b/spihelper.js
@@ -604,6 +604,32 @@ async function spiHelperGenerateForm () {
         }
       }
     }
+    const unnamedParameterRegex = /\s*\d*\s*/gi
+    const socklistResults = pagetext.match(/{{\s*sock\s?list\s*([^}]*)}}/gi)
+    if (socklistResults) {
+      for (let i = 0; i < socklistResults.length; i++) {
+        const match = socklistResults[i].match(/{{\s*sock\s?list\s*([^}]*)}}/i)[1]
+        // First split the text into parts based on the presence of a |
+        const arguments = match.split('|')
+        for (let j = 0; j < arguments.length; j++) {
+          // Now try to split based on "=", if wasn't able to it means it's an unnamed argument
+          const splitArgument = arguments[j].split('=')
+          let username = ''
+          if (splitArgument.length === 1) {
+            username = spiHelperNormalizeUsername(splitArgument[0])
+          } else if (unnamedParameterRegex.test(splitArgument[0])) {
+            username = spiHelperNormalizeUsername(splitArgument.slice(1).join('='))
+          }
+          if (username !== '') {
+            if (mw.util.isIPAddress(username, true) && !likelyips.includes(username)) {
+              likelyusers.push(username)
+            } else if (!likelyusers.includes(username)) {
+              likelyusers.push(username)
+            }
+          }
+        }
+      }
+    }
     // eslint-disable-next-line no-useless-escape
     const userRegex = /{{\s*(?:user|vandal|IP|noping|noping2)[^\|}{]*?\s*\|\s*(?:1=)?\s*([^\|}]*?)\s*}}/gi
     const userresults = pagetext.match(userRegex)

--- a/spihelper.js
+++ b/spihelper.js
@@ -608,12 +608,12 @@ async function spiHelperGenerateForm () {
     const socklistResults = pagetext.match(/{{\s*sock\s?list\s*([^}]*)}}/gi)
     if (socklistResults) {
       for (let i = 0; i < socklistResults.length; i++) {
-        const match = socklistResults[i].match(/{{\s*sock\s?list\s*([^}]*)}}/i)[1]
+        const socklistMatch = socklistResults[i].match(/{{\s*sock\s?list\s*([^}]*)}}/i)[1]
         // First split the text into parts based on the presence of a |
-        const arguments = match.split('|')
-        for (let j = 0; j < arguments.length; j++) {
+        const socklistArguments = socklistMatch.split('|')
+        for (let j = 0; j < socklistArguments.length; j++) {
           // Now try to split based on "=", if wasn't able to it means it's an unnamed argument
-          const splitArgument = arguments[j].split('=')
+          const splitArgument = socklistArguments[j].split('=')
           let username = ''
           if (splitArgument.length === 1) {
             username = spiHelperNormalizeUsername(splitArgument[0])

--- a/spihelper.js
+++ b/spihelper.js
@@ -604,7 +604,7 @@ async function spiHelperGenerateForm () {
         }
       }
     }
-    const unnamedParameterRegex = /\s*\d+\s*/gi
+    const unnamedParameterRegex = /^\s*\d+\s*$/i
     const socklistResults = pagetext.match(/{{\s*sock\s?list\s*([^}]*)}}/gi)
     if (socklistResults) {
       for (let i = 0; i < socklistResults.length; i++) {


### PR DESCRIPTION
As per https://en.wikipedia.org/wiki/Template_talk:SPI_report#Proposed_change_to_sock_list the socklist template is going to be used in Twinkle. The patch is at https://github.com/wikimedia-gadgets/twinkle/pull/1509 and has been merged into source. All that is from it being used on enwiki is a deployment. Because of this, and because there is discussion about changing the preload form to use socklist soon, the changes to support the socklist in -dev should be merged into main soon so that those using the main version of spihelper do have their version break.

This pull request has cherry-picked the relevant commits from the develop branch so that only the socklist detection code is a part of this pull request. I have tested the code currently in Dreamy-Jazz/main (which contains the cherry-picked commits) to ensure the socklist code works with the older version of spihelper and my testing brought no errors.