### PR TITLE
Update disabled state of lock checkbox on change of username

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -3035,6 +3035,12 @@ async function spiHelperGenerateBlockTableLine (name, defaultblock, id) {
   // Generate the select entries
   spiHelperGenerateSelect('spiHelper_block_tag' + id, spiHelperTagOptions)
   spiHelperGenerateSelect('spiHelper_block_tag_altmaster' + id, spiHelperAltMasterTagOptions)
+
+  // Add onlistener events to update the global lock checkbox if the username is changed between a IP address and username
+  $('#spiHelper_block_username' + id).on('change', (event) => {
+    let id = $(event.target).attr('id').replace('spiHelper_block_username', '')
+    $('#spiHelper_block_lock' + id).prop('disabled', mw.util.isIPAddress($(event.target).val(), true))
+  })
 }
 
 async function spiHelperGenerateLinksTableLine (username, id) {

--- a/spihelper.js
+++ b/spihelper.js
@@ -3038,7 +3038,7 @@ async function spiHelperGenerateBlockTableLine (name, defaultblock, id) {
 
   // Add onlistener events to update the global lock checkbox if the username is changed between a IP address and username
   $('#spiHelper_block_username' + id).on('change', (event) => {
-    let id = $(event.target).attr('id').replace('spiHelper_block_username', '')
+    const id = $(event.target).attr('id').replace('spiHelper_block_username', '')
     $('#spiHelper_block_lock' + id).prop('disabled', mw.util.isIPAddress($(event.target).val(), true))
   })
 }


### PR DESCRIPTION
On change for username box in block view to ensure the global lock checkbox is disabled only when the input field has a IP address.

Should mitigate #91 by ensuring that any change to the username field refreshes the checkbox state (and thus allows it to be selected if the username field doesn't contain an IP address).