### PR TITLE
level attribute in parse api has changed to int type

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -2780,7 +2780,7 @@ async function spiHelperGetInvestigationSectionIDs () {
   const dateSections = []
   for (let i = 0; i < response.parse.sections.length; i++) {
     // TODO: also check for presence of spi case status
-    if (response.parse.sections[i].level === '3') {
+    if (response.parse.sections[i].level === 3) {
       dateSections.push(response.parse.sections[i])
     }
   }


### PR DESCRIPTION
See also
https://gerrit.wikimedia.org/r/c/mediawiki/core/+/768247/4/includes/parser/Parser.php
https://gerrit.wikimedia.org/r/c/mediawiki/core/+/768247/4/tests/phpunit/includes/parser/ParserMethodsTest.php