### PR TITLE
Handle int or str as section level value [CRITICAL]

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -2396,7 +2396,7 @@ async function spiHelperGetInvestigationSectionIDs () {
   const dateSections = []
   for (let i = 0; i < response.parse.sections.length; i++) {
     // TODO: also check for presence of spi case status
-    if (response.parse.sections[i].level === '3') {
+    if (response.parse.sections[i].level == 3) {
       dateSections.push(response.parse.sections[i])
     }
   }

--- a/spihelper.js
+++ b/spihelper.js
@@ -2396,7 +2396,7 @@ async function spiHelperGetInvestigationSectionIDs () {
   const dateSections = []
   for (let i = 0; i < response.parse.sections.length; i++) {
     // TODO: also check for presence of spi case status
-    if (response.parse.sections[i].level == 3) {
+    if (parseInt(response.parse.sections[i].level) === 3) {
       dateSections.push(response.parse.sections[i])
     }
   }


### PR DESCRIPTION
This should fix the critical bug described by @roysmith [here](https://en.wikipedia.org/w/index.php?diff=1077793462&oldid=1077172445). The API parse action is currently giving `level` as an int, rather than a string as it previously did; however, on pages from before this change it's still treated as a str. I've talked to a dev about this, and it's not yet clear whether this was an intended change, and, if it wasn't, whether it will be reverted. Given all of that, then, an abstract equality comparison seems like the most backward- and forward-compatible solution.

[Demo'd on-wiki](https://en.wikipedia.org/w/index.php?title=User:Tamzin/spihelper.js&diff=prev&oldid=1077795874), [test successful](https://en.wikipedia.org/w/index.php?title=Wikipedia:Sockpuppet_investigations/RoySmith-Mobile&diff=1077796524&oldid=1077788094)