### PR TITLE
change advert link to "w:en:WP:SPIH"

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -268,7 +268,7 @@ const spiHelperHiddenCharNormRegex = /\u200E/g
 /* Other globals */
 
 /** @type{string} Advert to append to the edit summary of edits */
-const spihelperAdvert = ' (using [[:w:en:User:GeneralNotability/spihelper|spihelper.js]])'
+const spihelperAdvert = ' (using [[:w:en:WP:SPIH|spihelper.js]])'
 
 /* Used by the link view */
 const spiHelperLinkViewURLFormats = {


### PR DESCRIPTION
This reduces the length of edit summaries considerably in settings where all edits are reported with edit summaries given as text, like those channels used by the SPI clerk team.