### PR TITLE
add '1=' to {{rangeblock}} to escape equals signs

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -1284,7 +1284,7 @@ async function spiHelperPerformActions () {
             blockSummary = cublockTemplate + ': ' + blockSummary
           }
         } else if (isIPRange) {
-          blockSummary = '{{rangeblock| ' + blockSummary +
+          blockSummary = '{{rangeblock|1= ' + blockSummary +
             (blockEntry.acb ? '' : '|create=yes') + '}}'
         }
         const blockSuccess = await spiHelperBlockUser(


### PR DESCRIPTION
Avoids parsing issue in a case where `blockSummary` contains an equals sign.