### PR TITLE
Skip status action if checkbox was selected but ultimately unchanged

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -1162,7 +1162,7 @@ async function spiHelperPerformActions () {
       newCaseStatus = oldCaseStatus
     }
 
-    if (spiHelperActionsSelected.Case_act && newCaseStatus !== 'noaction' && newCaseStatus != oldCaseStatus) {
+    if (spiHelperActionsSelected.Case_act && newCaseStatus !== 'noaction' && newCaseStatus !== oldCaseStatus) {
       switch (newCaseStatus) {
         case 'reopen':
           newCaseStatus = 'open'

--- a/spihelper.js
+++ b/spihelper.js
@@ -1162,7 +1162,7 @@ async function spiHelperPerformActions () {
       newCaseStatus = oldCaseStatus
     }
 
-    if (spiHelperActionsSelected.Case_act && newCaseStatus !== 'noaction') {
+    if (spiHelperActionsSelected.Case_act && newCaseStatus !== 'noaction' && newCaseStatus != oldCaseStatus) {
       switch (newCaseStatus) {
         case 'reopen':
           newCaseStatus = 'open'


### PR DESCRIPTION
Prevents unnecessary additions such as 'changed case status from open to open' at [log](https://en.wikipedia.org/w/index.php?title=User:DatGuy/spihelper_log&diff=1114832645&oldid=1114777645&diffmode=source) and 'Marking request as open' at [SPI](https://en.wikipedia.org/w/index.php?title=Wikipedia:Sockpuppet_investigations/%D0%9A%D0%B0%D1%82%D0%B5%D1%80%D0%B8%D0%BD%D0%B0_%D0%96%D0%B0%D0%B4%D0%B0%D0%BD&diff=1114832641&oldid=1114823946&diffmode=source)