### PR TITLE
Fix user always existing locally

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -2632,9 +2632,9 @@ async function spiHelperDoesUserExistLocally (user) {
     const response = await api.get({
       action: 'query',
       list: 'allusers',
-      agulimit: '1',
-      agufrom: user,
-      aguto: user
+      aulimit: '1',
+      aufrom: user,
+      auto: user
     })
     if (response.query.allusers.length === 0) {
       // If the length is 0, then we couldn't find the local account so return false


### PR DESCRIPTION
agufrom and aguto are for "allglobalusers". This meant the parameters didn't exist, and it would always return the first ten registered users on the wiki, hence `true`.