### PR TITLE
tag as blocked for alt master who is a proven master

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -1049,7 +1049,7 @@ async function spiHelperTagUser (tagEntry, tagNonLocalAccounts, sockmaster, altm
     if (altmasterName && isMaster) {
       // If we have an altmaster and we're the master, swap a few values around
       sockmasterName = altmasterName
-      tag = altmasterTag
+      tag = 'blocked' ? altmasterTag === 'suspected' : altmasterTag
       altmasterName = ''
       altmasterTag = ''
       tagText += '\n'

--- a/spihelper.js
+++ b/spihelper.js
@@ -1049,7 +1049,7 @@ async function spiHelperTagUser (tagEntry, tagNonLocalAccounts, sockmaster, altm
     if (altmasterName && isMaster) {
       // If we have an altmaster and we're the master, swap a few values around
       sockmasterName = altmasterName
-      tag = 'blocked' ? altmasterTag === 'suspected' : altmasterTag
+      tag = altmasterTag === 'suspected' ? 'blocked' : altmasterTag
       altmasterName = ''
       altmasterTag = ''
       tagText += '\n'


### PR DESCRIPTION
Fixes https://en.wikipedia.org/w/index.php?title=User:Sahilangh&action=history, where it uses the "an editor has expressed a concern..." template.