### PR TITLE
Only include new archive notice when moving case

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -1773,7 +1773,7 @@ async function spiHelperLog (logString) {
  */
 async function spiHelperPostRenameCleanup (oldCasePage) {
   'use strict'
-  const replacementArchiveNotice = '<noinclude>__TOC__</noinclude>\n' + spiHelperMakeNewArchiveNotice(spiHelperCaseName, spiHelperArchiveNoticeParams) + '\n{{SPIpriorcases}}'
+  const replacementArchiveNotice = spiHelperMakeNewArchiveNotice(spiHelperCaseName, spiHelperArchiveNoticeParams)
   const oldCaseName = oldCasePage.replace(/Wikipedia:Sockpuppet investigations\//g, '')
 
   // Update previous SPI redirects to this location


### PR DESCRIPTION
TOC and {{SPIpriorcases}} have no effect after a case move and this prevents it from showing up at Wikipedia:Database reports/Malformed SPI Cases