### PR TITLE
don't backendify usernames when normalising

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -3542,8 +3542,6 @@ function spiHelperIsClerk () {
  * @return {string} Normalized username
  */
 function spiHelperNormalizeUsername (username) {
-  // Replace underscores with spaces
-  username = username.replace(/_/g, ' ')
   // Get rid of bad hidden characters
   username = username.replace(spiHelperHiddenCharNormRegex, '')
   // Remove leading and trailing spaces
@@ -3554,7 +3552,7 @@ function spiHelperNormalizeUsername (username) {
   } else if (username) {
     // For actual usernames, make sure the first letter is capitalized
     // Ensure consistent case conversions with PHP as per https://phabricator.wikimedia.org/T292824
-    username = new mw.Title(username).getMain()
+    username = new mw.Title(username).getMainText()
   }
   return username
 }


### PR DESCRIPTION
This was changed to fix #156, but introduced another bug where it replaces spaces with underscores, etc. Using getMainText() instead of getMain() seems to fixes it. Fixes stuff like [1](https://en.wikipedia.org/w/index.php?title=Wikipedia:Sockpuppet_investigations/LSS_2552&diff=prev&oldid=1193688149) [2](https://en.wikipedia.org/w/index.php?title=User:Djajay.lobo.143&diff=prev&oldid=1193686154)

```javascript

new mw.Title(" this is a test.").getMain() // bad :(
'This_is_a_test.'
new mw.Title("this_is_a_test").getMainText()
'This is a test'
new mw.Title(" this_is_a test. ").getMainText()
'This is a test.'
````