### PR TITLE
Add defensive check for skins without p-cactions menu

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -3426,6 +3426,10 @@ async function spiHelperAddLink () {
   await spiHelperLoadSettings()
   await mw.loader.load('mediawiki.util')
   const initLink = mw.util.addPortletLink('p-cactions', '#', 'SPI', 'ca-spiHelper')
+  // The skin didn't have a p-cactions menu so the menu addition failed. Exit early.
+  if (!initLink) {
+    return false;
+  }
   initLink.addEventListener('click', (e) => {
     e.preventDefault()
     return spiHelperInit()


### PR DESCRIPTION
The Minerva menu only has a p-cactions menu if advanced mode is enabled. Since addPortletLink can return null this should be handled in the gadget.