### PR TITLE
Misc fixes

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -928,7 +928,7 @@ async function updateForRole (view) {
  * Archives everything on the page that's eligible for archiving
  */
 async function spiHelperOneClickArchive () {
-  'use strict'
+  'use strict'  
   spiHelperActiveOperations.set('oneClickArchive', 'running')
 
   const pagetext = await spiHelperGetPageText(spiHelperPageName, false)
@@ -1671,11 +1671,11 @@ async function spiHelperPerformActions () {
     // Archive the case
     if (spiHelperSectionId === null) {
       // Archive the whole case
-      logMessage += '\n** Archived case'
+      logMessage += '\n** Archived case'      
       await spiHelperArchiveCase()
     } else {
       // Just archive the selected section
-      logMessage += '\n** Archived section'
+      logMessage += '\n** Archived section'      
       await spiHelperArchiveCaseSection(spiHelperSectionId)
     }
   } else if (spiHelperActionsSelected.Rename && renameTarget) {
@@ -1817,8 +1817,8 @@ async function spiHelperPostMergeCleanup (originalText) {
 /**
  * Archive all closed sections of a case
  */
-async function spiHelperArchiveCase () {
-  'use strict'
+async function spiHelperArchiveCase () {  
+  'use strict'  
   let i = 0
   let previousRev = 0
   while (i < spiHelperCaseSections.length) {
@@ -1864,7 +1864,7 @@ async function spiHelperArchiveCase () {
         await spiHelperEditPage(spiHelperGetArchiveName(), '', 'Removing redirect', false, 'nochange')
       }
       // Need an await here - if we have multiple sections archiving we don't want
-      // to stomp on each other
+      // to stomp on each other      
       await spiHelperArchiveCaseSection(sectionId)
       // need to re-fetch caseSections since the section numbering probably just changed,
       // also reset our index
@@ -1883,10 +1883,18 @@ async function spiHelperArchiveCaseSection (sectionId) {
   'use strict'
   let sectionText = await spiHelperGetPageText(spiHelperPageName, true, sectionId)
   sectionText = sectionText.replace(spiHelperCaseStatusRegex, '')
-  const newarchivetext = sectionText.substring(sectionText.search(spiHelperSectionRegex))
+  const newarchivetext = sectionText.substring(sectionText.search(spiHelperSectionRegex))  
+  let archivetext = await spiHelperGetPageText(spiHelperGetArchiveName(), true)  
+
+  const $statusLine = $('<li>').appendTo($('#spiHelper_status', document))
+  //Edit conflict check
+  if(archivetext.includes(sectionText)) {
+    $statusLine.addClass('spihelper-errortext').append('b').text('Looks like the page has been archived already')
+    return      
+  }
+
 
   // Update the archive
-  let archivetext = await spiHelperGetPageText(spiHelperGetArchiveName(), true)
   if (!archivetext) {
     archivetext = '__TOC__\n{{SPIarchive notice|1=' + spiHelperCaseName + '}}\n{{SPIpriorcases}}'
   } else {
@@ -1897,8 +1905,7 @@ async function spiHelperArchiveCaseSection (sectionId) {
     'Archiving case section from [[' + spiHelperGetInterwikiPrefix() + spiHelperPageName + ']]',
     false, spiHelperSettings.watchArchive, spiHelperSettings.watchArchiveExpiry)
 
-  if (!archiveSuccess) {
-    const $statusLine = $('<li>').appendTo($('#spiHelper_status', document))
+  if (!archiveSuccess) {    
     $statusLine.addClass('spihelper-errortext').append('b').text('Failed to update archive, not removing section from case page')
     return
   }

--- a/spihelper.js
+++ b/spihelper.js
@@ -1448,7 +1448,7 @@ async function spiHelperPerformActions () {
     if (needsAltmaster) {
       altmaster = prompt('Please enter the name of the alternate sockmaster: ', spiHelperCaseName) || spiHelperCaseName
     }
-
+    
     const tagNonLocalAccounts = $('#spiHelper_tagAccountsWithoutLocalAccount', $actionView).prop('checked')
     let blockingPromises
     if (spiHelperIsAdmin()) {
@@ -1486,10 +1486,10 @@ async function spiHelperPerformActions () {
       let needsPurge = false
       // True for each we need to check if the respective category (e.g.
       // "Suspected sockpuppets of Test") exists
-      const checkConfirmedCat = spiHelperTags.some((tagEntry) => tagEntry.tag === 'proven')
+      const checkConfirmedCat = spiHelperTags.some((tagEntry) => tagEntry.tag === 'proven') || spiHelperTags.some((tagEntry) => tagEntry.tag === 'confirmed')
       const checkSuspectedCat = spiHelperTags.some((tagEntry) => tagEntry.tag === 'blocked')
       const checkAltSuspectedCat = altmaster !== '' ? spiHelperTags.some((tagEntry) => tagEntry.altmasterTag !== '' && tagEntry.altmasterTag === 'suspected') : false
-      const checkAltConfirmedCat = altmaster !== '' ? spiHelperTags.some((tagEntry) => tagEntry.altmasterTag !== '' && tagEntry.altmasterTag === 'proven') : false
+      const checkAltConfirmedCat = altmaster !== '' ? spiHelperTags.some((tagEntry) => tagEntry.altmasterTag !== '' && tagEntry.altmasterTag === 'proven') || spiHelperTags.some((tagEntry) => tagEntry.altmasterTag !== '' && tagEntry.altmasterTag === 'confirmed') : false
 
       if (checkAltConfirmedCat) {
         const catname = 'Category:Wikipedia sockpuppets of ' + altmaster


### PR DESCRIPTION
This resolves issue 138, 151, 160.

The resolution for issue 138 is, as suggested in the discussion for that issue, to check if the text to be added to the archive is already present in the archive, and to bail out if it is.

Issue 160 is fairly straight forward bug. The script would only check if Category:Wikipedia sockpuppets of so-and-so exists, if accounts were being tagged as proven. As a result, if all sock are tagged as confirmed, a category would be required but not created. Setting the checkConfirmedCat variable to true when there are proven or confirmed tags, fixes the problem.

Issue 151, as described in the discussion for that issue, is a regex problem. If the note1 parameter contains a template, the end of that template is read as the end of the socklist, meaning any suspected socks appear after that are missed. The solution here is to simply not try to parse the wikitext at all, and instead play to the strengths of the language we're using by pulling the usernames out of the DOM instead. The checkuser and sock list template wrap their content in a span with a class of cuEntry that's not used anywhere else. I've tested this fix against all four currently supported skins, and it should also just work with Minerva if PR159 is accepted.