### PR TITLE
Optimize spiHelperArchiveCase (one-click archiving)

### DIFF
--- a/spihelper.js
+++ b/spihelper.js
@@ -251,7 +251,7 @@ const spiHelperCaseStatusRegex = /{{\s*SPI case status\s*\|?\s*(\S*?)\s*}}/i
 // Regex to match closed case statuses (close or closed)
 const spiHelperCaseClosedRegex = /^closed?$/i
 // Regex to match the closed case statuses with the full template string (used for optimized one-click archiving)
-const spiHelperCaseStatusClosedRegex = /{{\s*SPI case status\s*\|?\s*closed?\s*}}/i
+const spiHelperCaseStatusClosedRegex = /{{\s*SPI case status\s*\|?\s*closed?\s*}}/gi
 
 const spiHelperClerkStatusRegex = /{{(CURequest|awaitingadmin|clerk ?request|(?:self|requestand|cu)?endorse|inprogress|decline(?:-ip)?|moreinfo|relisted|onhold)}}/i
 
@@ -1825,7 +1825,7 @@ async function spiHelperArchiveCase () {
   let pageText = await spiHelperGetPageText(spiHelperPageName, true)
 
   // Remove all {{SPI case status|close(d)}} templates from the page text
-  pageText.replace(spiHelperCaseStatusClosedRegex, '')
+  pageText = pageText.replaceAll(spiHelperCaseStatusClosedRegex, '')
 
   let textToArchiveLines = []
   let textToKeepLines = []
@@ -1903,7 +1903,7 @@ async function spiHelperArchiveCase () {
   }
   archivetext += '\n' + textToArchive
   const archiveSuccess = await spiHelperEditPage(spiHelperGetArchiveName(), archivetext,
-    'Archiving closed cases from [[' + spiHelperGetInterwikiPrefix() + spiHelperPageName + ']]',
+    'Archiving closed section(s) from [[' + spiHelperGetInterwikiPrefix() + spiHelperPageName + ']]',
     false, spiHelperSettings.watchArchive, spiHelperSettings.watchArchiveExpiry)
 
   if (!archiveSuccess) {    
@@ -1912,7 +1912,7 @@ async function spiHelperArchiveCase () {
   }
 
   // Update case page to blank the sections we archived
-  await spiHelperEditPage(spiHelperPageName, textToKeep, 'Archiving closed cases to [[' + spiHelperGetInterwikiPrefix() + spiHelperGetArchiveName() + ']]',
+  await spiHelperEditPage(spiHelperPageName, textToKeep, 'Archiving closed section(s) to [[' + spiHelperGetInterwikiPrefix() + spiHelperGetArchiveName() + ']]',
     false, spiHelperSettings.watchCase, spiHelperSettings.watchCaseExpiry, spiHelperStartingRevID, null)
   // Update to the latest revision ID
   spiHelperStartingRevID = await spiHelperGetPageRev(spiHelperPageName)

--- a/spihelper.js
+++ b/spihelper.js
@@ -1832,7 +1832,8 @@ async function spiHelperArchiveCase () {
   let sectionLines = []
 
   // Now we will iterate line by line through pageText and decide if the line
-  // should be appended to sectionsToArchiveLines, which we will then append to the archive.
+  // should be appended to textToArchiveLines, which we will then append to the archive,
+  // or textToKeepLines, which will remain on the case page.
   let inClosedSection = false
   for (const line of pageText.split('\n')) {
     if (spiHelperSectionRegex.test(line)) {


### PR DESCRIPTION
## Problem

The current implementation of spiHelperArchiveCase is very inefficient. It goes section by section, blanking and archiving each one, spending many seconds on each section. If a particular SPI case has, say, five closed reports that need to be archived, that means we have to generate no less than 10 edits to archive the case and spend the better part of a minute waiting for the script to finish. When SPI is backlogged, these delays quickly pile up.

## Solution

Instead of going section by section, we can more optimally go through and do a "one-click archive" by grabbing the case page text only once, figuring out which lines need to be archived and which lines should be kept, and then submitting just two edits: one to archive and one to blank the archived sections. Doing this is tremendously more efficient: instead of waiting a minute to archive an SPI case that has many sections, the processing time is now down to just a couple seconds or so.

## Testing

I tested this in a test SPI for [a few edits](https://en.wikipedia.org/wiki/Special:Undelete/Wikipedia:Sockpuppet_investigations/Sandbox) then tried it out for real on a few SPI cases:

* Archiving one closed case: [blank](https://en.wikipedia.org/w/index.php?title=Wikipedia:Sockpuppet_investigations/Ces.althea162003&diff=prev&oldid=1325816019), [archive](https://en.wikipedia.org/w/index.php?title=Wikipedia:Sockpuppet_investigations/Ces.althea162003/Archive&diff=prev&oldid=1325816017)
* Archiving multiple closed cases at once: [blank](https://en.wikipedia.org/w/index.php?title=Wikipedia:Sockpuppet_investigations/Timelash&diff=prev&oldid=1325813386), [archive](https://en.wikipedia.org/w/index.php?title=Wikipedia:Sockpuppet_investigations/Timelash/Archive&diff=prev&oldid=1325813385)
* Archiving with a mix of open and closed cases:
    * Example 1: [blank](https://en.wikipedia.org/w/index.php?title=Wikipedia:Sockpuppet_investigations/TheChineseGroundnut&diff=prev&oldid=1325815168), [archive](https://en.wikipedia.org/w/index.php?title=Wikipedia:Sockpuppet_investigations/TheChineseGroundnut/Archive&diff=prev&oldid=1325815166)
    * Example 2: [blank](https://en.wikipedia.org/w/index.php?title=Wikipedia:Sockpuppet_investigations/Meister_und_Margarita&diff=prev&oldid=1325815342), [archive](https://en.wikipedia.org/w/index.php?title=Wikipedia:Sockpuppet_investigations/Meister_und_Margarita/Archive&diff=prev&oldid=1325815340)
* Creating a brand new archive (i.e. where the archive page did not exist beforehand): [blank](https://en.wikipedia.org/w/index.php?title=Wikipedia:Sockpuppet_investigations/Mekayltghas&diff=prev&oldid=1325813745), [archive](https://en.wikipedia.org/w/index.php?title=Wikipedia:Sockpuppet_investigations/Mekayltghas/Archive&oldid=1325813743)
* Moving archive to archive of archive if transclusion limit is reached: [move log](https://en.wikipedia.org/w/index.php?title=Special:Log&page=Wikipedia%3ASockpuppet_investigations%2FSheryOfficial%2FArchive&type=move)

## Issue

This partially addresses https://github.com/GeneralNotability/spihelper/issues/15 (allowing for archiving multiple sections at once but not closing multiple sections)